### PR TITLE
Feature/apple oauth2

### DIFF
--- a/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
@@ -21,6 +21,13 @@ public enum ErrorMessage {
     OAUTH_PROVIDER_NOT_SUPPORTED(BAD_REQUEST, "지원하지 않는 OAuth 제공자입니다."),
     OAUTH_AUTHENTICATION_FAILED(UNAUTHORIZED, "OAuth 인증에 실패했습니다."),
     
+    // Apple 관련 에러
+    APPLE_IDENTITY_TOKEN_INVALID(UNAUTHORIZED, "Apple Identity Token이 유효하지 않습니다."),
+    APPLE_IDENTITY_TOKEN_EXPIRED(UNAUTHORIZED, "Apple Identity Token이 만료되었습니다."),
+    APPLE_PUBLIC_KEY_NOT_FOUND(UNAUTHORIZED, "일치하는 Apple 공개키를 찾을 수 없습니다."),
+    APPLE_JWT_VERIFICATION_FAILED(UNAUTHORIZED, "Apple JWT 검증에 실패했습니다."),
+    APPLE_USER_INFO_MISSING(BAD_REQUEST, "Apple 사용자 정보가 누락되었습니다."),
+    
     // 인증 관련 에러
     AUTH_INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     AUTH_EXPIRED_TOKEN(UNAUTHORIZED, "만료된 토큰입니다."),

--- a/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
@@ -44,6 +44,9 @@ public class SecurityConfig {
                         .requestMatchers("/admin/cleanup-tokens").permitAll() // 임시 관리자 엔드포인트
                         .requestMatchers("/css/**", "/js/**", "/images/**", "/webjars/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        // Apple 테스트 경로 허용
+                        .requestMatchers("/api/auth/apple/**").permitAll()
+                        .requestMatchers("/apple-login-test.html").permitAll()
                         // OAuth2 관련 경로
                         .requestMatchers("/api/oauth2/**", "/api/login/oauth2/**").permitAll()
                         // 나머지는 인증 필요

--- a/src/main/java/com/example/cherrydan/oauth/controller/AppleAuthController.java
+++ b/src/main/java/com/example/cherrydan/oauth/controller/AppleAuthController.java
@@ -1,0 +1,76 @@
+package com.example.cherrydan.oauth.controller;
+
+import com.example.cherrydan.common.exception.AuthException;
+import com.example.cherrydan.common.exception.ErrorMessage;
+import com.example.cherrydan.common.response.ApiResponse;
+import com.example.cherrydan.oauth.dto.AppleLoginRequest;
+import com.example.cherrydan.oauth.dto.TokenDTO;
+import com.example.cherrydan.oauth.security.oauth2.CustomOAuth2UserService;
+import com.example.cherrydan.oauth.security.oauth2.user.AppleOAuth2UserInfo;
+import com.example.cherrydan.oauth.security.oauth2.user.OAuth2UserInfo;
+import com.example.cherrydan.oauth.service.AppleIdentityTokenService;
+import com.example.cherrydan.oauth.service.AuthService;
+import com.example.cherrydan.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth/apple")
+@RequiredArgsConstructor
+@Tag(name = "Apple 인증", description = "Apple Sign in with Apple 관련 API")
+public class AppleAuthController {
+
+    private final AppleIdentityTokenService appleIdentityTokenService;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    @Operation(summary = "Apple 로그인", description = "iOS에서 받은 Identity Token으로 Apple 로그인 처리")
+    public ResponseEntity<ApiResponse<TokenDTO>> appleLogin(@RequestBody AppleLoginRequest request) {
+        // 1. 입력 값 검증
+        validateAppleLoginRequest(request);
+        
+        // 2. Apple Identity Token 검증
+        Map<String, Object> userInfo = appleIdentityTokenService.verifyIdentityToken(request.getIdentityToken());
+        
+        // 3. OAuth2UserInfo 객체 생성 (JWT 정보 + iOS 정보 결합)
+        OAuth2UserInfo oAuth2UserInfo = new AppleOAuth2UserInfo(userInfo);
+        
+        // 4. 사용자 조회 또는 생성 (CustomOAuth2UserService 사용)
+        User user = customOAuth2UserService.processAppleUser(oAuth2UserInfo);
+        
+        // 5. Access Token과 Refresh Token 생성
+        TokenDTO tokenDTO = authService.generateTokens(user);
+        
+        log.info("Apple 로그인 성공: userId={}, email={}, name={}", user.getId(), user.getEmail(), user.getName());
+        
+        return ResponseEntity.ok(ApiResponse.success(tokenDTO));
+    }
+
+    /**
+     * Apple 로그인 요청 검증
+     */
+    private void validateAppleLoginRequest(AppleLoginRequest request) {
+        if (request == null) {
+            throw new AuthException(ErrorMessage.INVALID_REQUEST);
+        }
+        
+        if (!StringUtils.hasText(request.getIdentityToken())) {
+            throw new AuthException(ErrorMessage.APPLE_USER_INFO_MISSING);
+        }
+        
+        // JWT 형식 기본 검증 (3개 파트로 구성되어야 함)
+        String[] tokenParts = request.getIdentityToken().split("\\.");
+        if (tokenParts.length != 3) {
+            throw new AuthException(ErrorMessage.APPLE_IDENTITY_TOKEN_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/example/cherrydan/oauth/controller/AuthController.java
+++ b/src/main/java/com/example/cherrydan/oauth/controller/AuthController.java
@@ -4,7 +4,7 @@ import com.example.cherrydan.common.exception.AuthException;
 import com.example.cherrydan.common.exception.ErrorMessage;
 import com.example.cherrydan.common.exception.UserException;
 import com.example.cherrydan.common.response.ApiResponse;
-import com.example.cherrydan.oauth.dto.TokenDTO;
+import com.example.cherrydan.oauth.dto.AccessTokenDTO;
 import com.example.cherrydan.oauth.dto.UserInfoDTO;
 import com.example.cherrydan.oauth.security.jwt.JwtTokenProvider;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
@@ -38,7 +38,7 @@ public class AuthController {
      */
     @Operation(summary = "Access Token 갱신", description = "Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<TokenDTO>> refresh(
+    public ResponseEntity<ApiResponse<AccessTokenDTO>> refresh(
             @CookieValue(value = "refreshToken", required = false) String refreshToken) {
 
         Optional<User> userOpt = validateToken(refreshToken);
@@ -50,7 +50,7 @@ public class AuthController {
         
         log.info("Access Token 갱신 완료: 사용자 ID = {}", user.getId());
         
-        return ResponseEntity.ok(ApiResponse.success("토큰 갱신이 완료되었습니다.", new TokenDTO(newAccessToken)));
+        return ResponseEntity.ok(ApiResponse.success("토큰 갱신이 완료되었습니다.", new AccessTokenDTO(newAccessToken)));
     }
 
     private Optional<User> validateToken(String refreshToken) {

--- a/src/main/java/com/example/cherrydan/oauth/dto/AccessTokenDTO.java
+++ b/src/main/java/com/example/cherrydan/oauth/dto/AccessTokenDTO.java
@@ -1,0 +1,16 @@
+package com.example.cherrydan.oauth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "액세스 토큰 정보 (토큰 갱신용)")
+public class AccessTokenDTO {
+    
+    @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+}

--- a/src/main/java/com/example/cherrydan/oauth/dto/AppleLoginRequest.java
+++ b/src/main/java/com/example/cherrydan/oauth/dto/AppleLoginRequest.java
@@ -1,0 +1,16 @@
+package com.example.cherrydan.oauth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "Apple 로그인 요청")
+public class AppleLoginRequest {
+    
+    @Schema(description = "Apple Identity Token (JWT)", example = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...", required = true)
+    private String identityToken;
+}

--- a/src/main/java/com/example/cherrydan/oauth/dto/TokenDTO.java
+++ b/src/main/java/com/example/cherrydan/oauth/dto/TokenDTO.java
@@ -13,4 +13,7 @@ public class TokenDTO {
     
     @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String accessToken;
+    
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String refreshToken;
 }

--- a/src/main/java/com/example/cherrydan/oauth/model/AuthProvider.java
+++ b/src/main/java/com/example/cherrydan/oauth/model/AuthProvider.java
@@ -5,8 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "인증 제공자 유형")
 public enum AuthProvider {
 //    @Schema(description = "Google 로그인") GOOGLE,
-    @Schema(description = "GitHub 로그인") GITHUB,
     @Schema(description = "Kakao 로그인") KAKAO,
-    @Schema(description = "Naver 로그인") NAVER
-//    @Schema(description = "Apple 로그인") APPLE
+    @Schema(description = "Naver 로그인") NAVER,
+    @Schema(description = "Apple 로그인") APPLE
 }

--- a/src/main/java/com/example/cherrydan/oauth/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/cherrydan/oauth/security/oauth2/CustomOAuth2UserService.java
@@ -1,5 +1,7 @@
 package com.example.cherrydan.oauth.security.oauth2;
 
+import com.example.cherrydan.common.exception.AuthException;
+import com.example.cherrydan.common.exception.ErrorMessage;
 import com.example.cherrydan.oauth.model.AuthProvider;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import com.example.cherrydan.oauth.security.oauth2.exception.OAuth2AuthenticationProcessingException;
@@ -66,6 +68,26 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // UserDetails 객체 생성 및 반환 (Build and return UserDetails)
         return UserDetailsImpl.build(user, oAuth2User.getAttributes());
     }
+
+    /**
+     * Apple 사용자 정보 처리 (Apple용 별도 메서드)
+     * Process Apple user information manually (not through OAuth2 flow)
+     */
+    public User processAppleUser(OAuth2UserInfo appleUserInfo) {
+        try {
+            // 이메일 확인 (Validate email)
+            validateEmail(appleUserInfo);
+
+            // 사용자 조회 또는 생성 (Find or create user)
+            return findOrCreateUser(appleUserInfo, "apple");
+        } catch (OAuth2AuthenticationProcessingException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            log.error("Apple 사용자 처리 중 오류 발생: {}", ex.getMessage());
+            throw new AuthException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
 
     /**
      * 이메일 유효성 검증

--- a/src/main/java/com/example/cherrydan/oauth/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/cherrydan/oauth/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,24 +1,14 @@
 package com.example.cherrydan.oauth.security.oauth2;
 
-import com.example.cherrydan.common.exception.ErrorMessage;
-import com.example.cherrydan.common.exception.OAuthException;
-import com.example.cherrydan.oauth.security.jwt.JwtTokenProvider;
+import com.example.cherrydan.oauth.dto.TokenDTO;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
-import com.example.cherrydan.oauth.service.RefreshTokenService;
-import com.example.cherrydan.user.domain.User;
-import com.example.cherrydan.user.repository.UserRepository;
-import com.example.cherrydan.oauth.model.AuthProvider;
-import com.example.cherrydan.oauth.security.oauth2.user.OAuth2UserInfo;
-import com.example.cherrydan.oauth.security.oauth2.user.OAuth2UserInfoFactory;
-import jakarta.servlet.http.Cookie;
+import com.example.cherrydan.oauth.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -26,15 +16,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtTokenProvider tokenProvider;
-    private final RefreshTokenService refreshTokenService;
+    private final AuthService authService;
 
     @Value("${oauth2.redirect.success-url}")
     private String redirectSuccessUrl;
@@ -47,50 +35,28 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         try {
             UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
-            Long userId = userDetails.getId();
-            String userEmail = userDetails.getEmail();
 
-            // 액세스 토큰 생성
-            String accessToken = tokenProvider.generateAccessToken(userId, userEmail);
+            // AuthService를 통해 토큰 생성 (UserDetailsImpl 직접 전달)
+            TokenDTO tokenDTO = authService.generateTokens(userDetails);
 
-            // 기존 리프레시 토큰이 있는지 확인
-            Optional<String> existingRefreshToken = refreshTokenService.findRefreshTokenByUserId(userId);
-            String refreshToken;
+            log.info("OAuth2 로그인 성공: userId={}, email={}, provider={}", 
+                    userDetails.getId(), userDetails.getEmail(), userDetails.getProvider());
 
-            if (existingRefreshToken.isPresent() && tokenProvider.validateToken(existingRefreshToken.get())) {
-                // 유효한 리프레시 토큰이 있으면 재사용
-                refreshToken = existingRefreshToken.get();
-                log.info("기존 리프레시 토큰 재사용: 사용자 ID = {}", userId);
-            } else {
-                // 없거나 만료된 경우 새로 생성
-                refreshToken = tokenProvider.generateRefreshToken(userId);
-                // 새 리프레시 토큰을 DB에 저장
-                refreshTokenService.saveRefreshToken(userId, refreshToken);
-                log.info("새 리프레시 토큰 생성: 사용자 ID = {}", userId);
-            }
-
-            // Refresh Token을 HttpOnly 쿠키로 설정
-            Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
-            refreshCookie.setHttpOnly(true);
-            refreshCookie.setSecure(false);
-            refreshCookie.setPath("/");
-            refreshCookie.setMaxAge(14 * 24 * 60 * 60);
-            response.addCookie(refreshCookie);
-
-            // 리다이렉트 URL 생성
+            // 리다이렉트 URL에 TokenDTO 정보 포함
             String targetUrl = UriComponentsBuilder.fromUriString(redirectSuccessUrl)
-                    .queryParam("token", accessToken)
+                    .queryParam("accessToken", tokenDTO.getAccessToken())
+                    .queryParam("refreshToken", tokenDTO.getRefreshToken())
                     .build().toUriString();
 
             // 리다이렉트 수행
             getRedirectStrategy().sendRedirect(request, response, targetUrl);
 
         } catch (Exception e) {
-            log.error("OAuth 인증 성공 처리 중 오류 발생: {}", e.getMessage(), e);
+            log.error("OAuth2 인증 성공 처리 중 오류 발생: {}", e.getMessage(), e);
 
-            // 오류 발생 시에도 UriComponentsBuilder를 사용하여 일관된 방식으로 리다이렉트
+            // 오류 발생 시 실패 URL로 리다이렉트
             String errorUrl = UriComponentsBuilder.fromUriString(redirectFailureUrl)
-                    .queryParam("message", "로그인 성공 처리 중 오류가 발생했습니다.")
+                    .queryParam("error", URLEncoder.encode("로그인 처리 중 오류가 발생했습니다.", StandardCharsets.UTF_8))
                     .build().toUriString();
 
             getRedirectStrategy().sendRedirect(request, response, errorUrl);

--- a/src/main/java/com/example/cherrydan/oauth/security/oauth2/user/AppleOAuth2UserInfo.java
+++ b/src/main/java/com/example/cherrydan/oauth/security/oauth2/user/AppleOAuth2UserInfo.java
@@ -1,0 +1,39 @@
+package com.example.cherrydan.oauth.security.oauth2.user;
+
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+
+public class AppleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public AppleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        // Apple은 사용자 이름을 Identity Token에 포함하지 않음
+        // 필요시 이메일 앞부분을 사용하거나 기본값 설정
+        String email = getEmail();
+        if (email != null && email.contains("@")) {
+            return email.substring(0, email.indexOf("@"));
+        }
+        return "Apple User";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        // Apple은 프로필 이미지를 제공하지 않음
+        return null;
+    }
+}

--- a/src/main/java/com/example/cherrydan/oauth/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/example/cherrydan/oauth/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -14,6 +14,8 @@ public class OAuth2UserInfoFactory {
                 return new KakaoOAuth2UserInfo(attributes);
             case NAVER:
                 return new NaverOAuth2UserInfo(attributes);
+            case APPLE:
+                return new AppleOAuth2UserInfo(attributes);
             default:
                 throw new OAuthException(ErrorMessage.OAUTH_PROVIDER_NOT_SUPPORTED);
         }

--- a/src/main/java/com/example/cherrydan/oauth/service/AppleIdentityTokenService.java
+++ b/src/main/java/com/example/cherrydan/oauth/service/AppleIdentityTokenService.java
@@ -1,0 +1,148 @@
+package com.example.cherrydan.oauth.service;
+
+import com.example.cherrydan.common.exception.AuthException;
+import com.example.cherrydan.common.exception.ErrorMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class AppleIdentityTokenService {
+
+    @Value("${apple.keys-url}")
+    private String APPLE_KEYS_URL;
+    @Value("${apple.issuer}")
+    private String APPLE_ISSUER;
+    @Value("${apple.client-id}")
+    private String APPLE_AUDIENCE;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Apple Identity Token을 검증하고 사용자 정보를 반환
+     */
+    public Map<String, Object> verifyIdentityToken(String identityToken) {
+        try {
+            log.info("Apple Identity Token 검증 시작");
+            
+            // 1. Apple 공개 키 가져오기
+            PublicKey publicKey = getApplePublicKey(identityToken);
+            
+            // 2. JWT 토큰 검증
+            Claims claims = Jwts.parser()
+                    .setSigningKey(publicKey)
+                    .requireIssuer(APPLE_ISSUER)
+                    .requireAudience(APPLE_AUDIENCE)
+                    .build()
+                    .parseClaimsJws(identityToken)
+                    .getBody();
+
+            log.info("Apple Identity Token 검증 성공: sub={}", claims.getSubject());
+            
+            // 3. Claims를 Map으로 변환하여 반환
+            return claims;
+            
+        } catch (ExpiredJwtException e) {
+            log.error("Apple Identity Token 만료: {}", e.getMessage());
+            throw new AuthException(ErrorMessage.APPLE_IDENTITY_TOKEN_EXPIRED);
+        } catch (JwtException e) {
+            log.error("Apple Identity Token 검증 실패: {}", e.getMessage());
+            throw new AuthException(ErrorMessage.APPLE_JWT_VERIFICATION_FAILED);
+        } catch (AuthException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Apple Identity Token 검증 중 예상치 못한 오류: {}", e.getMessage(), e);
+            throw new AuthException(ErrorMessage.APPLE_IDENTITY_TOKEN_INVALID);
+        }
+    }
+
+    /**
+     * Apple 공개키를 가져와서 JWT 검증에 사용할 PublicKey 객체 생성
+     */
+    private PublicKey getApplePublicKey(String identityToken) {
+        try {
+            // JWT 헤더에서 kid 추출
+            String kid = getKidFromToken(identityToken);
+            log.debug("JWT에서 추출한 kid: {}", kid);
+            
+            // Apple 공개키 목록 가져오기
+            String response = restTemplate.getForObject(APPLE_KEYS_URL, String.class);
+            Map<String, Object> keys = objectMapper.readValue(response, Map.class);
+            List<Map<String, Object>> keyList = (List<Map<String, Object>>) keys.get("keys");
+            
+            // kid와 일치하는 키 찾기
+            Map<String, Object> matchingKey = keyList.stream()
+                    .filter(key -> kid.equals(key.get("kid")))
+                    .findFirst()
+                    .orElseThrow(() -> {
+                        log.error("일치하는 Apple 공개키를 찾을 수 없음. kid: {}", kid);
+                        return new AuthException(ErrorMessage.APPLE_PUBLIC_KEY_NOT_FOUND);
+                    });
+            
+            // RSA 공개키 생성
+            String nStr = (String) matchingKey.get("n");
+            String eStr = (String) matchingKey.get("e");
+            
+            byte[] nBytes = Base64.getUrlDecoder().decode(nStr);
+            byte[] eBytes = Base64.getUrlDecoder().decode(eStr);
+            
+            BigInteger modulus = new BigInteger(1, nBytes);
+            BigInteger exponent = new BigInteger(1, eBytes);
+            
+            RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(modulus, exponent);
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            
+            log.debug("Apple RSA 공개키 생성 완료");
+            return keyFactory.generatePublic(publicKeySpec);
+            
+        } catch (AuthException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Apple 공개키 생성 중 오류: {}", e.getMessage(), e);
+            throw new AuthException(ErrorMessage.APPLE_PUBLIC_KEY_NOT_FOUND);
+        }
+    }
+
+    /**
+     * JWT 토큰 헤더에서 kid(Key ID) 추출
+     */
+    private String getKidFromToken(String token) {
+        try {
+            String[] tokenParts = token.split("\\.");
+            if (tokenParts.length != 3) {
+                throw new AuthException(ErrorMessage.APPLE_IDENTITY_TOKEN_INVALID);
+            }
+            
+            String header = new String(Base64.getUrlDecoder().decode(tokenParts[0]));
+            Map<String, Object> headerMap = objectMapper.readValue(header, Map.class);
+            
+            String kid = (String) headerMap.get("kid");
+            if (kid == null || kid.trim().isEmpty()) {
+                throw new AuthException(ErrorMessage.APPLE_IDENTITY_TOKEN_INVALID);
+            }
+            
+            return kid;
+        } catch (AuthException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("JWT 헤더에서 kid 추출 실패: {}", e.getMessage(), e);
+            throw new AuthException(ErrorMessage.APPLE_IDENTITY_TOKEN_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/example/cherrydan/oauth/service/AuthService.java
+++ b/src/main/java/com/example/cherrydan/oauth/service/AuthService.java
@@ -3,8 +3,10 @@ package com.example.cherrydan.oauth.service;
 import com.example.cherrydan.common.exception.AuthException;
 import com.example.cherrydan.common.exception.ErrorMessage;
 import com.example.cherrydan.common.exception.UserException;
+import com.example.cherrydan.oauth.dto.AccessTokenDTO;
 import com.example.cherrydan.oauth.dto.TokenDTO;
 import com.example.cherrydan.oauth.security.jwt.JwtTokenProvider;
+import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import com.example.cherrydan.oauth.service.RefreshTokenService;
 import com.example.cherrydan.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -22,39 +24,75 @@ public class AuthService {
     private final RefreshTokenService refreshTokenService;
     private final JwtTokenProvider tokenProvider;
 
+    /**
+     * Refresh Token으로 새로운 Access Token 발급
+     */
     @Transactional
-    public TokenDTO refreshToken(String refreshToken) {
-        try {
-            // Refresh Token 유효성 검증
-            if (refreshToken == null) {
-                throw new AuthException(ErrorMessage.AUTH_REFRESH_TOKEN_NOT_FOUND);
-            }
+    public AccessTokenDTO refreshToken(String refreshToken) {
+        // Refresh Token 유효성 검증
+        if (refreshToken == null) {
+            throw new AuthException(ErrorMessage.AUTH_REFRESH_TOKEN_NOT_FOUND);
+        }
 
-            if (!refreshTokenService.validateRefreshToken(refreshToken)) {
-                throw new AuthException(ErrorMessage.AUTH_INVALID_REFRESH_TOKEN);
-            }
-
-            // 사용자 정보 조회
-            Optional<User> userOpt = refreshTokenService.getUserByRefreshToken(refreshToken);
-            if (userOpt.isEmpty()) {
-                throw new UserException(ErrorMessage.USER_NOT_FOUND);
-            }
-
-            User user = userOpt.get();
-            
-            // 새 Access Token 생성
-            String newAccessToken = tokenProvider.generateAccessToken(user.getId(), user.getEmail());
-            
-            log.info("토큰 갱신 완료: 사용자 ID = {}", user.getId());
-            
-            // TokenDTO 반환
-            return new TokenDTO(newAccessToken);
-            
-        } catch (AuthException | UserException e) {
-            throw e; // 이미 적절한 커스텀 예외이므로 그대로 전파
-        } catch (Exception e) {
-            log.error("토큰 갱신 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+        if (!refreshTokenService.validateRefreshToken(refreshToken)) {
             throw new AuthException(ErrorMessage.AUTH_INVALID_REFRESH_TOKEN);
         }
+
+        // 사용자 정보 조회
+        Optional<User> userOpt = refreshTokenService.getUserByRefreshToken(refreshToken);
+        if (userOpt.isEmpty()) {
+            throw new UserException(ErrorMessage.USER_NOT_FOUND);
+        }
+
+        User user = userOpt.get();
+        
+        // 새 Access Token 생성
+        String newAccessToken = tokenProvider.generateAccessToken(user.getId(), user.getEmail());
+        
+        log.info("토큰 갱신 완료: 사용자 ID = {}", user.getId());
+        
+        // AccessTokenDTO 반환 (Refresh Token 없음)
+        return new AccessTokenDTO(newAccessToken);
+    }
+
+    /**
+     * 사용자를 위한 Access Token과 Refresh Token 생성 (로그인용)
+     */
+    @Transactional
+    public TokenDTO generateTokens(User user) {
+        // Access Token 생성
+        String accessToken = tokenProvider.generateAccessToken(user.getId(), user.getEmail());
+
+        // Refresh Token 생성
+        String refreshToken = tokenProvider.generateRefreshToken(user.getId());
+
+        // Refresh Token을 DB에 저장
+        refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
+
+        log.info("토큰 생성 완료: 사용자 ID = {}", user.getId());
+
+        // TokenDTO 반환 (Access + Refresh Token 모두 포함)
+        return new TokenDTO(accessToken, refreshToken);
+    }
+
+    /**
+     * UserDetailsImpl로부터 Access Token과 Refresh Token 생성 (OAuth2용)
+     */
+    @Transactional
+    public TokenDTO generateTokens(UserDetailsImpl userDetails) {
+        // Access Token 생성
+        String accessToken = tokenProvider.generateAccessToken(userDetails.getId(), userDetails.getEmail());
+        
+        // Refresh Token 생성
+        String refreshToken = tokenProvider.generateRefreshToken(userDetails.getId());
+        
+        // Refresh Token을 DB에 저장
+        refreshTokenService.saveRefreshToken(userDetails.getId(), refreshToken);
+        
+        log.info("OAuth2 토큰 생성 완료: 사용자 ID = {}, provider = {}", 
+                userDetails.getId(), userDetails.getProvider());
+        
+        // TokenDTO 반환 (Access + Refresh Token 모두 포함)
+        return new TokenDTO(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/example/cherrydan/user/domain/User.java
+++ b/src/main/java/com/example/cherrydan/user/domain/User.java
@@ -35,6 +35,7 @@ public class User extends BaseTimeEntity {
     private String socialId;
     
     @Enumerated(EnumType.STRING)
+    @Column(length = 20)
     private AuthProvider provider;
     
     private String uuid;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -70,3 +70,8 @@ oauth2:
   redirect:
     success-url: ${OAUTH2_REDIRECT_SUCCESS_URL}
     failure-url: ${OAUTH2_REDIRECT_FAILURE_URL}
+
+apple:
+  client-id: ${APPLE_CLIENT_ID}
+  issuer: https://appleid.apple.com
+  keys-url: https://appleid.apple.com/auth/keys


### PR DESCRIPTION
# Pull Request: Apple Sign in with Apple 구현

## 변경 사항 요약
iOS 앱에서 받은 Apple Identity Token을 백엔드에서 검증하여 사용자 인증을 처리하고, JWT 기반 Access Token과 Refresh Token을 발급하는 Apple 로그인 기능을 구현했습니다.

## 변경 내용

### 🔧 주요 구현 사항
- **AppleIdentityTokenService**: Apple 공개키를 사용한 JWT 검증 로직
- **AppleAuthController**: Apple 로그인 전용 REST API 엔드포인트
- **AppleLoginRequest**: Identity Token만 받는 간소화된 DTO
- **AppleOAuth2UserInfo**: Apple JWT Claims를 OAuth2UserInfo로 변환

### 🔑 기술적 특징
- Apple 공개키(JWK) 동적 조회 및 RSA 서명 검증
- JWT Claims에서 직접 사용자 정보(email, sub) 추출
- 기존 CustomOAuth2UserService와 AuthService 재사용으로 일관성 유지
- Apple 특화 예외 처리 및 상세 로깅

### 📡 API 엔드포인트
```
POST /api/auth/apple/login
Request: { "identityToken": "eyJhbGciOiJSUzI1NiI..." }
Response: { "accessToken": "...", "refreshToken": "..." }
```

### 수동 테스트 시나리오
1. iOS 앱에서 Apple Sign In 수행
2. 받은 Identity Token을 백엔드로 전송
3. Access Token과 Refresh Token 정상 발급 확인
