### PR TITLE
Feature/#28 mypage

### DIFF
--- a/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
@@ -86,6 +86,15 @@ public enum ErrorMessage {
     INQUIRY_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "문의 등록에 실패했습니다."),
     INQUIRY_REPLY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "문의 답변 등록에 실패했습니다."),
 
+    // 푸시 알림 설정 관련 에러
+    PUSH_SETTINGS_NOT_FOUND(NOT_FOUND, "푸시 알림 설정을 찾을 수 없습니다."),
+    PUSH_SETTINGS_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "푸시 알림 설정 생성에 실패했습니다."),
+    PUSH_SETTINGS_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "푸시 알림 설정 업데이트에 실패했습니다."),
+    PUSH_SETTINGS_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "푸시 알림 설정 삭제에 실패했습니다."),
+    PUSH_CATEGORY_INVALID(BAD_REQUEST, "잘못된 푸시 알림 카테고리입니다."),
+    PUSH_SETTINGS_ACCESS_DENIED(FORBIDDEN, "푸시 알림 설정에 대한 접근 권한이 없습니다."),
+    PUSH_SETTINGS_INVALID_REQUEST(BAD_REQUEST, "잘못된 푸시 알림 설정 요청입니다."),
+
     // 공통 에러
     INVALID_REQUEST(BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_PARAMETER(BAD_REQUEST, "잘못된 파라미터입니다."),

--- a/src/main/java/com/example/cherrydan/common/exception/PushException.java
+++ b/src/main/java/com/example/cherrydan/common/exception/PushException.java
@@ -1,0 +1,11 @@
+package com.example.cherrydan.common.exception;
+
+/**
+ * 푸시 알림 설정 관련 예외
+ */
+public class PushException extends BaseException {
+    
+    public PushException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+} 

--- a/src/main/java/com/example/cherrydan/inquiry/service/InquiryService.java
+++ b/src/main/java/com/example/cherrydan/inquiry/service/InquiryService.java
@@ -40,6 +40,12 @@ public class InquiryService {
         return inquiries.map(InquiryResponseDTO::from);
     }
 
+    public InquiryResponseDTO getInquiryDetail(Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new InquiryException(ErrorMessage.INQUIRY_NOT_FOUND));
+        return InquiryResponseDTO.from(inquiry);
+    }
+
     /**
      * 상태별 사용자 문의 목록 조회
      */
@@ -78,9 +84,9 @@ public class InquiryService {
 
             return InquiryResponseDTO.from(savedInquiry);
         } catch (Exception e) {
-            log.error("문의 등록 실패: userId={}, error={}", userId, e.getMessage());
+            log.error("문의 등록 실패: userId={}, error={}", userId, e.getMessage());   
             throw new InquiryException(ErrorMessage.INQUIRY_CREATE_FAILED);
-        }
+        }                                                                       
     }
 
     public InquiryResponseDTO getInquiryDetail(Long inquiryId, Long userId) {

--- a/src/main/java/com/example/cherrydan/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/cherrydan/mypage/controller/MyPageController.java
@@ -7,6 +7,9 @@ import com.example.cherrydan.inquiry.service.InquiryService;
 import com.example.cherrydan.notice.dto.NoticeResponseDTO;
 import com.example.cherrydan.notice.service.NoticeService;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
+import com.example.cherrydan.push.dto.PushSettingsRequestDTO;
+import com.example.cherrydan.push.dto.PushSettingsResponseDTO;
+import com.example.cherrydan.push.service.PushSettingsService;
 import com.example.cherrydan.version.dto.AppVersionResponseDTO;
 import com.example.cherrydan.version.service.AppVersionService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,6 +32,33 @@ public class MyPageController {
     private final AppVersionService appVersionService;
     private final NoticeService noticeService;
     private final InquiryService inquiryService;
+    private final PushSettingsService pushSettingsService;
+
+    @Operation(summary = "푸시 알림 설정 조회")
+    @GetMapping("/push-settings")
+    public ResponseEntity<ApiResponse<PushSettingsResponseDTO>> getPushSettings(
+            @AuthenticationPrincipal UserDetailsImpl currentUser) {
+        PushSettingsResponseDTO response = pushSettingsService.getUserPushSettings(currentUser.getId());
+        return ResponseEntity.ok(ApiResponse.success("푸시 알림 설정 조회가 완료되었습니다.", response));
+    }
+
+    @Operation(summary = "푸시 알림 설정 업데이트")
+    @PutMapping("/push-settings")
+    public ResponseEntity<ApiResponse<PushSettingsResponseDTO>> updatePushSettings(
+            @AuthenticationPrincipal UserDetailsImpl currentUser,
+            @RequestBody PushSettingsRequestDTO request) {
+        PushSettingsResponseDTO response = pushSettingsService.updatePushSettings(currentUser.getId(), request);
+        return ResponseEntity.ok(ApiResponse.success("푸시 알림 설정이 업데이트되었습니다.", response));
+    }
+
+    @Operation(summary = "푸시 알림 전체 on/off")
+    @PatchMapping("/push-settings/toggle")
+    public ResponseEntity<ApiResponse<PushSettingsResponseDTO>> togglePushEnabled(
+            @AuthenticationPrincipal UserDetailsImpl currentUser,
+            @RequestParam boolean enabled) {
+        PushSettingsResponseDTO response = pushSettingsService.togglePushEnabled(currentUser.getId(), enabled);
+        return ResponseEntity.ok(ApiResponse.success("푸시 알림 전체 설정이 변경되었습니다.", response));
+    }
 
     @Operation(summary = "앱 버전 정보 조회")
     @GetMapping("/version")
@@ -49,6 +79,13 @@ public class MyPageController {
     public ResponseEntity<ApiResponse<NoticeResponseDTO>> getNoticeDetail(@PathVariable Long id) {
         NoticeResponseDTO response = noticeService.getNoticeDetail(id);
         return ResponseEntity.ok(ApiResponse.success("공지사항 상세 조회가 완료되었습니다.", response));
+    }
+
+    @Operation(summary = "내 문의 상세 조회")
+    @GetMapping("/inquiries/{id}")
+    public ResponseEntity<ApiResponse<InquiryResponseDTO>> getMyInquiryDetail(@PathVariable Long id) {
+        InquiryResponseDTO response = inquiryService.getInquiryDetail(id);
+        return ResponseEntity.ok(ApiResponse.success("문의 상세 조회가 완료되었습니다.", response));
     }
 
     @Operation(summary = "내 문의 목록 조회")

--- a/src/main/java/com/example/cherrydan/oauth/model/RefreshToken.java
+++ b/src/main/java/com/example/cherrydan/oauth/model/RefreshToken.java
@@ -21,8 +21,7 @@ public class RefreshToken extends BaseTimeEntity {
     @Column(name = "refresh_token", nullable = false)
     private String refreshToken;
 
-    @OneToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    @OneToOne(mappedBy = "refreshToken")
     @JsonIgnore
     private User user;
 }

--- a/src/main/java/com/example/cherrydan/push/dto/PushCategory.java
+++ b/src/main/java/com/example/cherrydan/push/dto/PushCategory.java
@@ -1,0 +1,17 @@
+package com.example.cherrydan.push.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum PushCategory {
+    ACTIVITY("활동 알림 (공고 마감, 선정결과 등)"),
+    PERSONALIZED("맞춤 알림 (키워드 알림 등)"),
+    SERVICE("서비스 알림 (안내공지, 1:1 문의 답변)"),
+    MARKETING("마케팅 알림 (이벤트, 프로모션)");
+
+    private final String description;
+
+    PushCategory(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/cherrydan/push/dto/PushSettingsRequestDTO.java
+++ b/src/main/java/com/example/cherrydan/push/dto/PushSettingsRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.cherrydan.push.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushSettingsRequestDTO {
+    private Boolean activityEnabled;
+    private Boolean personalizedEnabled;
+    private Boolean serviceEnabled;
+    private Boolean marketingEnabled;
+    private Boolean pushEnabled;
+}

--- a/src/main/java/com/example/cherrydan/push/dto/PushSettingsResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/push/dto/PushSettingsResponseDTO.java
@@ -1,0 +1,25 @@
+package com.example.cherrydan.push.dto;
+import com.example.cherrydan.user.domain.UserPushSettings;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PushSettingsResponseDTO {
+    private Boolean activityEnabled;
+    private Boolean personalizedEnabled;
+    private Boolean serviceEnabled;
+    private Boolean marketingEnabled;
+    private Boolean pushEnabled;
+
+    public static PushSettingsResponseDTO from(UserPushSettings settings) {
+        return PushSettingsResponseDTO.builder()
+                .activityEnabled(settings.getActivityEnabled())
+                .personalizedEnabled(settings.getPersonalizedEnabled())
+                .serviceEnabled(settings.getServiceEnabled())
+                .marketingEnabled(settings.getMarketingEnabled())
+                .pushEnabled(settings.getPushEnabled())
+                .build();
+    }
+}

--- a/src/main/java/com/example/cherrydan/push/service/PushSettingsService.java
+++ b/src/main/java/com/example/cherrydan/push/service/PushSettingsService.java
@@ -1,0 +1,167 @@
+package com.example.cherrydan.push.service;
+
+import com.example.cherrydan.common.exception.ErrorMessage;
+import com.example.cherrydan.common.exception.PushException;
+import com.example.cherrydan.common.exception.UserException;
+import com.example.cherrydan.push.dto.PushSettingsRequestDTO;
+import com.example.cherrydan.push.dto.PushSettingsResponseDTO;
+import com.example.cherrydan.push.dto.PushCategory;
+import com.example.cherrydan.user.domain.User;
+import com.example.cherrydan.user.domain.UserPushSettings;
+import com.example.cherrydan.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PushSettingsService {
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자 푸시 알림 설정 조회
+     */
+    public PushSettingsResponseDTO getUserPushSettings(Long userId) {
+        log.info("푸시 알림 설정 조회 시작 - userId: {}", userId);
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+
+        UserPushSettings settings = user.getPushSettings();
+        if (settings == null) {
+            log.info("기본 푸시 알림 설정 생성 - userId: {}", userId);
+            settings = createDefaultPushSettings(user);
+        }
+
+        log.info("푸시 알림 설정 조회 완료 - userId: {}, pushEnabled: {}", userId, settings.getPushEnabled());
+        return PushSettingsResponseDTO.from(settings);
+    }
+
+    /**
+     * 사용자 푸시 알림 설정 업데이트
+     */
+    public PushSettingsResponseDTO updatePushSettings(Long userId, PushSettingsRequestDTO request) {
+        log.info("푸시 알림 설정 업데이트 시작 - userId: {}, request: {}", userId, request);
+        
+        if (request == null) {
+            throw new PushException(ErrorMessage.PUSH_SETTINGS_INVALID_REQUEST);
+        }
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+
+        UserPushSettings settings = user.getPushSettings();
+        if (settings == null) {
+            log.info("기본 푸시 알림 설정 생성 후 업데이트 - userId: {}", userId);
+            settings = createDefaultPushSettings(user);
+        }
+
+        try {
+            settings.updateSettings(
+                    request.getActivityEnabled(),
+                    request.getPersonalizedEnabled(),
+                    request.getServiceEnabled(),
+                    request.getMarketingEnabled(),
+                    request.getPushEnabled()
+            );
+
+            log.info("푸시 알림 설정 업데이트 완료 - userId: {}, pushEnabled: {}", userId, settings.getPushEnabled());
+            return PushSettingsResponseDTO.from(settings);
+        } catch (Exception e) {
+            log.error("푸시 알림 설정 업데이트 실패 - userId: {}, error: {}", userId, e.getMessage());
+            throw new PushException(ErrorMessage.PUSH_SETTINGS_UPDATE_FAILED);
+        }
+    }
+
+    /**
+     * 전체 푸시 알림 on/off
+     */
+    public PushSettingsResponseDTO togglePushEnabled(Long userId, boolean enabled) {
+        log.info("전체 푸시 알림 토글 시작 - userId: {}, enabled: {}", userId, enabled);
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+
+        UserPushSettings settings = user.getPushSettings();
+        if (settings == null) {
+            log.info("기본 푸시 알림 설정 생성 후 토글 - userId: {}", userId);
+            settings = createDefaultPushSettings(user);
+        }
+
+        try {
+            // pushEnabled는 마스터 스위치 역할 (카테고리 설정은 보존)
+            settings.setPushEnabled(enabled);
+            log.info("전체 푸시 알림 토글 완료 - userId: {}, enabled: {} (카테고리 설정 보존)", userId, enabled);
+            return PushSettingsResponseDTO.from(settings);
+        } catch (Exception e) {
+            log.error("전체 푸시 알림 토글 실패 - userId: {}, error: {}", userId, e.getMessage());
+            throw new PushException(ErrorMessage.PUSH_SETTINGS_UPDATE_FAILED);
+        }
+    }
+
+    /**
+     * 특정 카테고리 푸시 알림 허용 여부 확인
+     */
+    public boolean isPushAllowed(Long userId, PushCategory category) {
+        log.info("푸시 알림 허용 여부 확인 - userId: {}, category: {}", userId, category);
+        
+        if (category == null) {
+            log.warn("잘못된 푸시 카테고리 - userId: {}", userId);
+            throw new PushException(ErrorMessage.PUSH_CATEGORY_INVALID);
+        }
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+
+        UserPushSettings settings = user.getPushSettings();
+        if (settings == null) {
+            log.info("기본 푸시 알림 설정 생성 후 확인 - userId: {}", userId);
+            settings = createDefaultPushSettings(user);
+        }
+
+        // 전체 푸시가 꺼져있으면 모든 알림 차단
+        if (!settings.getPushEnabled()) {
+            log.info("전체 푸시 알림 비활성화 - userId: {}", userId);
+            return false;
+        }
+
+        // 전체 푸시가 켜져있을 때만 세부 설정 확인
+        boolean isAllowed = switch (category) {
+            case ACTIVITY -> settings.getActivityEnabled();
+            case PERSONALIZED -> settings.getPersonalizedEnabled();
+            case SERVICE -> settings.getServiceEnabled();
+            case MARKETING -> settings.getMarketingEnabled();
+        };
+        
+        log.info("푸시 알림 허용 여부 확인 완료 - userId: {}, category: {}, allowed: {}", userId, category, isAllowed);
+        return isAllowed;
+    }
+
+    /**
+     * 기본 푸시 설정 생성
+     */
+    public UserPushSettings createDefaultPushSettings(User user) {
+        log.info("기본 푸시 알림 설정 생성 - userId: {}", user.getId());
+        
+        try {
+            UserPushSettings defaultSettings = UserPushSettings.builder()
+                    .activityEnabled(true)
+                    .personalizedEnabled(true)
+                    .serviceEnabled(true)
+                    .marketingEnabled(true)
+                    .pushEnabled(true)
+                    .build();
+
+            user.setPushSettings(defaultSettings);
+
+            log.info("기본 푸시 알림 설정 생성 완료 - userId: {}", user.getId());
+            return defaultSettings;
+        } catch (Exception e) {
+            log.error("기본 푸시 알림 설정 생성 실패 - userId: {}, error: {}", user.getId(), e.getMessage());
+            throw new PushException(ErrorMessage.PUSH_SETTINGS_CREATE_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/example/cherrydan/user/domain/User.java
+++ b/src/main/java/com/example/cherrydan/user/domain/User.java
@@ -50,8 +50,13 @@ public class User extends BaseTimeEntity {
     // 프로필 이미지 URL
     private String picture;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "refresh_token_id")
     private RefreshToken refreshToken;
+
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "push_settings_id")
+    private UserPushSettings pushSettings;
 
     // OAuth 정보 업데이트 (기존 사용자)
     public void updateOAuth2Info(String name, String picture) {

--- a/src/main/java/com/example/cherrydan/user/domain/UserPushSettings.java
+++ b/src/main/java/com/example/cherrydan/user/domain/UserPushSettings.java
@@ -1,0 +1,55 @@
+package com.example.cherrydan.user.domain;
+
+import com.example.cherrydan.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_push_settings")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(callSuper = false)
+public class UserPushSettings extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(mappedBy = "pushSettings", fetch = FetchType.LAZY)
+    private User user;
+
+    @Builder.Default
+    @Column(name = "activity_enabled")
+    private Boolean activityEnabled = true;
+
+    @Builder.Default
+    @Column(name = "personalized_enabled")
+    private Boolean personalizedEnabled = true;
+
+    @Builder.Default
+    @Column(name = "service_enabled")
+    private Boolean serviceEnabled = true;
+
+    @Builder.Default
+    @Column(name = "marketing_enabled")
+    private Boolean marketingEnabled = true;
+
+    @Builder.Default
+    @Column(name = "push_enabled")
+    private Boolean pushEnabled = true;
+
+    public void updateSettings(Boolean activityEnabled, Boolean personalizedEnabled,
+                               Boolean serviceEnabled, Boolean marketingEnabled, Boolean pushEnabled) {
+        if (activityEnabled != null) this.activityEnabled = activityEnabled;
+        if (personalizedEnabled != null) this.personalizedEnabled = personalizedEnabled;
+        if (serviceEnabled != null) this.serviceEnabled = serviceEnabled;
+        if (marketingEnabled != null) this.marketingEnabled = marketingEnabled;
+        if (pushEnabled != null) this.pushEnabled = pushEnabled;
+    }
+}


### PR DESCRIPTION
# Pull Request: 푸시 알림 설정 기능 구현

#28 

## 변경 사항 요약
사용자가 푸시 알림 카테고리별로 개인화된 설정을 관리할 수 있는 기능을 추가했습니다. 전체 알림 on/off와 개별 카테고리 설정을 독립적으로 제어할 수 있습니다.

## 변경 내용
- `UserPushSettings` 엔티티 추가 (활동, 맞춤, 서비스, 마케팅 알림 설정)
- `PushSettingsService` 구현 (JPA Cascade + Dirty Checking 활용)
- `PushException` 커스텀 예외 및 에러 메시지 추가
- MyPageController에 푸시 설정 API 3개 추가 (조회, 업데이트, 전체 토글)
- User 엔티티와 1:1 연관관계 설정

## 성능 영향 (선택 사항)
- JPA 연관관계 활용으로 불필요한 Repository Layer 제거
- Dirty Checking으로 효율적인 업데이트 처리


## 참고 사항
- Repository 패턴 대신 JPA 연관관계를 활용하여 코드 복잡성을 줄였습니다