### PR TITLE
[feature] #15 내 체험단 & 홈 광고 배너 API 개발

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
@@ -1,0 +1,59 @@
+package com.example.cherrydan.campaign.controller;
+
+import com.example.cherrydan.campaign.dto.CampaignStatusRequestDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusResponseDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusListResponseDTO;
+import com.example.cherrydan.campaign.service.CampaignStatusService;
+import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/campaigns/my-status")
+@RequiredArgsConstructor
+public class CampaignStatusController {
+    private final CampaignStatusService campaignStatusService;
+
+    @GetMapping
+    public ResponseEntity<CampaignStatusListResponseDTO> getMyStatusListWithCount(
+        @AuthenticationPrincipal UserDetailsImpl currentUser
+    ) {
+        Long userId = currentUser.getId();
+        return ResponseEntity.ok(campaignStatusService.getStatusListWithCountByUser(userId));
+    }
+
+    @PostMapping
+    public ResponseEntity<CampaignStatusResponseDTO> createOrRecoverStatus(
+        @RequestBody CampaignStatusRequestDTO requestDTO,
+        @AuthenticationPrincipal UserDetailsImpl currentUser
+    ) {
+        requestDTO.setUserId(currentUser.getId());
+        return ResponseEntity.ok(campaignStatusService.createOrRecoverStatus(requestDTO));
+    }
+
+    @PatchMapping
+    public ResponseEntity<CampaignStatusResponseDTO> updateStatus(
+        @RequestBody CampaignStatusRequestDTO requestDTO,
+        @AuthenticationPrincipal UserDetailsImpl currentUser
+    ) {
+        requestDTO.setUserId(currentUser.getId());
+        return ResponseEntity.ok(campaignStatusService.updateStatus(requestDTO));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteStatus(
+        @RequestBody DeleteRequest request,
+        @AuthenticationPrincipal UserDetailsImpl currentUser
+    ) {
+        campaignStatusService.deleteStatus(request.getCampaignId(), currentUser.getId());
+        return ResponseEntity.ok().build();
+    }
+
+    public static class DeleteRequest {
+        private Long campaignId;
+        public Long getCampaignId() { return campaignId; }
+        public void setCampaignId(Long campaignId) { this.campaignId = campaignId; }
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
@@ -3,6 +3,7 @@ package com.example.cherrydan.campaign.controller;
 import com.example.cherrydan.campaign.dto.CampaignStatusRequestDTO;
 import com.example.cherrydan.campaign.dto.CampaignStatusResponseDTO;
 import com.example.cherrydan.campaign.dto.CampaignStatusListResponseDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusPopupResponseDTO;
 import com.example.cherrydan.campaign.service.CampaignStatusService;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +50,13 @@ public class CampaignStatusController {
     ) {
         campaignStatusService.deleteStatus(request.getCampaignId(), currentUser.getId());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/popup")
+    public ResponseEntity<CampaignStatusPopupResponseDTO> getPopupStatus(
+        @AuthenticationPrincipal UserDetailsImpl currentUser
+    ) {
+        return ResponseEntity.ok(campaignStatusService.getPopupStatusByUser(currentUser.getId()));
     }
 
     public static class DeleteRequest {

--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
@@ -10,13 +10,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "CampaignStatus", description = "내 체험단 상태 관리 및 팝업 API")
 @RestController
 @RequestMapping("/api/campaigns/my-status")
 @RequiredArgsConstructor
 public class CampaignStatusController {
     private final CampaignStatusService campaignStatusService;
 
+    @Operation(summary = "내 체험단 상태 전체 조회", description = "userId 기준 전체 상태 조회(상태별 리스트+카운트)")
     @GetMapping
     public ResponseEntity<CampaignStatusListResponseDTO> getMyStatusListWithCount(
         @AuthenticationPrincipal UserDetailsImpl currentUser
@@ -25,6 +32,7 @@ public class CampaignStatusController {
         return ResponseEntity.ok(campaignStatusService.getStatusListWithCountByUser(userId));
     }
 
+    @Operation(summary = "내 체험단 상태 생성/변경", description = "기존 데이터 있으면 is_active or status 변경, 없으면 생성")
     @PostMapping
     public ResponseEntity<CampaignStatusResponseDTO> createOrRecoverStatus(
         @RequestBody CampaignStatusRequestDTO requestDTO,
@@ -34,6 +42,7 @@ public class CampaignStatusController {
         return ResponseEntity.ok(campaignStatusService.createOrRecoverStatus(requestDTO));
     }
 
+    @Operation(summary = "내 체험단 상태 변경", description = "is_active or status 변경")
     @PatchMapping
     public ResponseEntity<CampaignStatusResponseDTO> updateStatus(
         @RequestBody CampaignStatusRequestDTO requestDTO,
@@ -43,6 +52,7 @@ public class CampaignStatusController {
         return ResponseEntity.ok(campaignStatusService.updateStatus(requestDTO));
     }
 
+    @Operation(summary = "내 체험단 상태 삭제", description = "campaignId만 받아서 삭제")
     @DeleteMapping
     public ResponseEntity<Void> deleteStatus(
         @RequestBody DeleteRequest request,
@@ -52,6 +62,7 @@ public class CampaignStatusController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "내 체험단 노출 팝업 조회", description = "신청/선정/등록 상태 중 기간이 지난 데이터만 최대 4개씩, 각 상태별 총 개수와 함께 반환")
     @GetMapping("/popup")
     public ResponseEntity<CampaignStatusPopupResponseDTO> getPopupStatus(
         @AuthenticationPrincipal UserDetailsImpl currentUser

--- a/src/main/java/com/example/cherrydan/campaign/domain/CampaignStatus.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/CampaignStatus.java
@@ -1,0 +1,34 @@
+package com.example.cherrydan.campaign.domain;
+
+import com.example.cherrydan.user.domain.User;
+import com.example.cherrydan.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "campaign_status")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CampaignStatus extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "campaign_id")
+    private Campaign campaign;
+
+    @Enumerated(EnumType.ORDINAL)
+    private CampaignStatusType status;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isActive = true;
+} 

--- a/src/main/java/com/example/cherrydan/campaign/domain/CampaignStatusType.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/CampaignStatusType.java
@@ -1,0 +1,24 @@
+package com.example.cherrydan.campaign.domain;
+
+public enum CampaignStatusType {
+    APPLY("apply", "신청"),
+    SELECTED("selected", "선정"),
+    REGISTERED("registered", "등록"),
+    ENDED("ended", "종료");
+
+    private final String code;
+    private final String label;
+
+    CampaignStatusType(String code, String label) {
+        this.code = code;
+        this.label = label;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/domain/CampaignStatusType.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/CampaignStatusType.java
@@ -1,5 +1,8 @@
 package com.example.cherrydan.campaign.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "캠페인 상태 타입 (APPLY: 신청, SELECTED: 선정, REGISTERED: 등록, ENDED: 종료)")
 public enum CampaignStatusType {
     APPLY("apply", "신청"),
     SELECTED("selected", "선정"),

--- a/src/main/java/com/example/cherrydan/campaign/dto/BookmarkResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/BookmarkResponseDTO.java
@@ -6,7 +6,6 @@ import com.example.cherrydan.campaign.domain.CampaignPlatformType;
 import com.example.cherrydan.campaign.domain.SnsPlatformType;
 import lombok.Builder;
 import lombok.Getter;
-import java.time.LocalDateTime;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -44,7 +43,7 @@ public class BookmarkResponseDTO {
                 .build();
     }
 
-    private static List<String> getPlatforms(Campaign campaign) {
+    public static List<String> getPlatforms(Campaign campaign) {
         List<String> platforms = new ArrayList<>();
         if (Boolean.TRUE.equals(campaign.getYoutube())) platforms.add(SnsPlatformType.YOUTUBE.getLabel());
         if (Boolean.TRUE.equals(campaign.getShorts())) platforms.add("쇼츠");
@@ -57,7 +56,7 @@ public class BookmarkResponseDTO {
         return platforms;
     }
 
-    private static String getReviewerAnnouncementStatus(LocalDate reviewerAnnouncement) {
+    public static String getReviewerAnnouncementStatus(LocalDate reviewerAnnouncement) {
         if (reviewerAnnouncement == null) return null;
         LocalDate today = LocalDate.now();
         long days = ChronoUnit.DAYS.between(today, reviewerAnnouncement);
@@ -70,12 +69,12 @@ public class BookmarkResponseDTO {
         }
     }
 
-    private static String getCampaignPlatformLabel(String code) {
+    public static String getCampaignPlatformLabel(String code) {
         if (code == null) return null;
         try {
             return CampaignPlatformType.fromCode(code).getLabel();
         } catch (IllegalArgumentException e) {
-            return code; // 매칭 안 되면 코드 그대로 반환
+            return code;
         }
     }
 } 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
@@ -55,9 +55,9 @@ public class CampaignResponseDTO {
         LocalDate today = LocalDate.now();
         long days = ChronoUnit.DAYS.between(today, reviewerAnnouncement);
         if (days > 0) {
-            return "발표 " + days + "일 전";
+            return days + "일 남음";
         } else if (days < 0) {
-            return "발표 " + Math.abs(days) + "일 지남";
+            return Math.abs(days) + "일 지남";
         } else {
             return "오늘 발표";
         }

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusListResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusListResponseDTO.java
@@ -1,0 +1,16 @@
+package com.example.cherrydan.campaign.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class CampaignStatusListResponseDTO {
+    private List<CampaignStatusResponseDTO> apply;
+    private List<CampaignStatusResponseDTO> selected;
+    private List<CampaignStatusResponseDTO> registered;
+    private List<CampaignStatusResponseDTO> ended;
+    private Map<String, Long> count;
+} 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusListResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusListResponseDTO.java
@@ -4,13 +4,20 @@ import lombok.Builder;
 import lombok.Getter;
 import java.util.List;
 import java.util.Map;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @Builder
+@Schema(description = "내 체험단 상태 목록 및 카운트 응답 DTO")
 public class CampaignStatusListResponseDTO {
+    @Schema(description = "신청 상태 리스트")
     private List<CampaignStatusResponseDTO> apply;
+    @Schema(description = "선정 상태 리스트")
     private List<CampaignStatusResponseDTO> selected;
+    @Schema(description = "등록 상태 리스트")
     private List<CampaignStatusResponseDTO> registered;
+    @Schema(description = "종료 상태 리스트")
     private List<CampaignStatusResponseDTO> ended;
+    @Schema(description = "상태별 개수 맵", example = "{'apply':4,'selected':2,'registered':1,'ended':3}")
     private Map<String, Long> count;
 } 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusPopupResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusPopupResponseDTO.java
@@ -1,16 +1,25 @@
 package com.example.cherrydan.campaign.dto;
 
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Getter;
-import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @Builder
+@Schema(description = "내 체험단 팝업용 상태 응답 DTO")
 public class CampaignStatusPopupResponseDTO {
+    @Schema(description = "신청 상태 총 개수", example = "4")
     private long applyTotal;
+    @Schema(description = "선정 상태 총 개수", example = "2")
     private long selectedTotal;
+    @Schema(description = "등록 상태 총 개수", example = "1")
     private long registeredTotal;
+    @Schema(description = "신청 상태 리스트")
     private List<CampaignStatusResponseDTO> apply;
+    @Schema(description = "선정 상태 리스트")
     private List<CampaignStatusResponseDTO> selected;
+    @Schema(description = "등록 상태 리스트")
     private List<CampaignStatusResponseDTO> registered;
-} 
+}

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusPopupResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusPopupResponseDTO.java
@@ -1,0 +1,16 @@
+package com.example.cherrydan.campaign.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+public class CampaignStatusPopupResponseDTO {
+    private long applyTotal;
+    private long selectedTotal;
+    private long registeredTotal;
+    private List<CampaignStatusResponseDTO> apply;
+    private List<CampaignStatusResponseDTO> selected;
+    private List<CampaignStatusResponseDTO> registered;
+} 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.cherrydan.campaign.dto;
+
+import com.example.cherrydan.campaign.domain.CampaignStatusType;
+import lombok.Getter;
+import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+@Getter
+@Setter
+public class CampaignStatusRequestDTO {
+    private Long campaignId;
+    @JsonIgnore
+    private Long userId;
+    private CampaignStatusType status;
+    private Boolean isActive;
+} 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
@@ -4,6 +4,7 @@ import com.example.cherrydan.campaign.domain.CampaignStatusType;
 import lombok.Getter;
 import lombok.Setter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @Setter
@@ -11,6 +12,7 @@ public class CampaignStatusRequestDTO {
     private Long campaignId;
     @JsonIgnore
     private Long userId;
+    @Schema(description = "캠페인 상태 타입 (APPLY: 신청, SELECTED: 선정, REGISTERED: 등록, ENDED: 종료)", example = "APPLY", allowableValues = {"APPLY", "SELECTED", "REGISTERED", "ENDED"})
     private CampaignStatusType status;
     private Boolean isActive;
 } 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
@@ -5,12 +5,14 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "캠페인 상태 응답 DTO")
 public class CampaignStatusResponseDTO {
     private Long id;
     private Long campaignId;

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
@@ -1,0 +1,57 @@
+package com.example.cherrydan.campaign.dto;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CampaignStatusResponseDTO {
+    private Long id;
+    private Long campaignId;
+    private Long userId;
+    private String reviewerAnnouncementStatus;
+    private String statusLabel;
+    private Boolean isActive;
+    private String title;
+    private String benefit;
+    private String detailUrl;
+    private String imageUrl;
+    private int applicantCount;
+    private int recruitCount;
+    private List<String> snsPlatforms;
+    private String campaignPlatform;
+    @JsonIgnore private LocalDate reviewerAnnouncement;
+    @JsonIgnore private LocalDate contentSubmissionEnd;
+    @JsonIgnore private LocalDate resultAnnouncement;
+
+    public static String getStatusMessage(LocalDate date, String type) {
+        if (date == null) return null;
+        LocalDate today = LocalDate.now();
+        long days = ChronoUnit.DAYS.between(today, date);
+        String prefix = "";
+        switch (type) {
+            case "bookmark":
+                prefix = "신청 마감 ";
+                break;
+            case "apply":
+            case "ended":
+                prefix = "발표 ";
+                break;
+            case "selected":
+                prefix = "방문 마감 ";
+                break;
+            case "registered":
+                prefix = "리뷰 마감 ";
+                break;
+        }
+        if (days > 0) return prefix + days + "일 전";
+        if (days < 0) return prefix + Math.abs(days) + "일 지남";
+        return "오늘" + prefix.replace(" ", "");
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/repository/CampaignStatusRepository.java
+++ b/src/main/java/com/example/cherrydan/campaign/repository/CampaignStatusRepository.java
@@ -1,0 +1,17 @@
+package com.example.cherrydan.campaign.repository;
+
+import com.example.cherrydan.campaign.domain.CampaignStatus;
+import com.example.cherrydan.campaign.domain.Campaign;
+import com.example.cherrydan.user.domain.User;
+import com.example.cherrydan.campaign.domain.CampaignStatusType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface CampaignStatusRepository extends JpaRepository<CampaignStatus, Long> {
+    List<CampaignStatus> findByCampaignAndIsActiveTrue(Campaign campaign);
+    List<CampaignStatus> findByUserAndIsActiveTrue(User user);
+    Optional<CampaignStatus> findByUserAndCampaignAndIsActiveTrue(User user, Campaign campaign);
+    long countByCampaignAndStatusAndIsActiveTrue(Campaign campaign, CampaignStatusType status);
+    Optional<CampaignStatus> findByUserAndCampaign(User user, Campaign campaign);
+} 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusService.java
@@ -3,10 +3,12 @@ package com.example.cherrydan.campaign.service;
 import com.example.cherrydan.campaign.dto.CampaignStatusRequestDTO;
 import com.example.cherrydan.campaign.dto.CampaignStatusResponseDTO;
 import com.example.cherrydan.campaign.dto.CampaignStatusListResponseDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusPopupResponseDTO;
 
 public interface CampaignStatusService {
     CampaignStatusResponseDTO createOrRecoverStatus(CampaignStatusRequestDTO requestDTO);
     CampaignStatusListResponseDTO getStatusListWithCountByUser(Long userId);
     CampaignStatusResponseDTO updateStatus(CampaignStatusRequestDTO requestDTO);
     void deleteStatus(Long campaignId, Long userId);
+    CampaignStatusPopupResponseDTO getPopupStatusByUser(Long userId);
 } 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusService.java
@@ -1,0 +1,12 @@
+package com.example.cherrydan.campaign.service;
+
+import com.example.cherrydan.campaign.dto.CampaignStatusRequestDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusResponseDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusListResponseDTO;
+
+public interface CampaignStatusService {
+    CampaignStatusResponseDTO createOrRecoverStatus(CampaignStatusRequestDTO requestDTO);
+    CampaignStatusListResponseDTO getStatusListWithCountByUser(Long userId);
+    CampaignStatusResponseDTO updateStatus(CampaignStatusRequestDTO requestDTO);
+    void deleteStatus(Long campaignId, Long userId);
+} 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusServiceImpl.java
@@ -1,0 +1,194 @@
+package com.example.cherrydan.campaign.service;
+
+import com.example.cherrydan.campaign.domain.Campaign;
+import com.example.cherrydan.campaign.domain.CampaignStatus;
+import com.example.cherrydan.campaign.domain.CampaignStatusType;
+import com.example.cherrydan.campaign.dto.BookmarkResponseDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusRequestDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusResponseDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusListResponseDTO;
+import com.example.cherrydan.campaign.repository.CampaignRepository;
+import com.example.cherrydan.campaign.repository.CampaignStatusRepository;
+import com.example.cherrydan.campaign.domain.CampaignPlatformType;
+import com.example.cherrydan.campaign.domain.SnsPlatformType;
+import com.example.cherrydan.user.domain.User;
+import com.example.cherrydan.user.repository.UserRepository;
+import com.example.cherrydan.common.exception.BaseException;
+import com.example.cherrydan.common.exception.UserException;
+import com.example.cherrydan.common.exception.ErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.time.LocalDate;
+
+
+@Service
+@RequiredArgsConstructor
+public class CampaignStatusServiceImpl implements CampaignStatusService {
+    private final CampaignStatusRepository campaignStatusRepository;
+    private final CampaignRepository campaignRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public CampaignStatusResponseDTO createOrRecoverStatus(CampaignStatusRequestDTO requestDTO) {
+        User user = userRepository.findById(requestDTO.getUserId())
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        Campaign campaign = campaignRepository.findById(requestDTO.getCampaignId())
+                .orElseThrow(() -> new BaseException(ErrorMessage.RESOURCE_NOT_FOUND));
+
+        Optional<CampaignStatus> optional = campaignStatusRepository.findByUserAndCampaign(user, campaign);
+
+        CampaignStatus status;
+        if (optional.isPresent()) {
+            status = optional.get();
+            status.setIsActive(true);
+            status.setStatus(requestDTO.getStatus());
+        } else {
+            status = CampaignStatus.builder()
+                    .user(user)
+                    .campaign(campaign)
+                    .status(requestDTO.getStatus())
+                    .isActive(true)
+                    .build();
+        }
+        CampaignStatus saved = campaignStatusRepository.save(status);
+        return toDTO(saved);
+    }
+
+    @Override
+    @Transactional
+    public CampaignStatusResponseDTO updateStatus(CampaignStatusRequestDTO requestDTO) {
+        User user = userRepository.findById(requestDTO.getUserId())
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        Campaign campaign = campaignRepository.findById(requestDTO.getCampaignId())
+                .orElseThrow(() -> new BaseException(ErrorMessage.RESOURCE_NOT_FOUND));
+        CampaignStatus status = campaignStatusRepository.findByUserAndCampaign(user, campaign)
+                .orElseThrow(() -> new BaseException(ErrorMessage.RESOURCE_NOT_FOUND));
+        if (requestDTO.getIsActive() != null) {
+            status.setIsActive(requestDTO.getIsActive());
+        }
+        if (requestDTO.getStatus() != null) {
+            status.setStatus(requestDTO.getStatus());
+        }
+        CampaignStatus saved = campaignStatusRepository.save(status);
+        return toDTO(saved);
+    }
+
+    @Override
+    @Transactional
+    public void deleteStatus(Long campaignId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(() -> new BaseException(ErrorMessage.RESOURCE_NOT_FOUND));
+        Optional<CampaignStatus> status = campaignStatusRepository.findByUserAndCampaign(user, campaign);
+        if (status.isEmpty()) {
+            throw new BaseException(ErrorMessage.RESOURCE_NOT_FOUND);
+        }
+        campaignStatusRepository.delete(status.get());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CampaignStatusListResponseDTO getStatusListWithCountByUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        List<CampaignStatusResponseDTO> apply = new ArrayList<>();
+        List<CampaignStatusResponseDTO> selected = new ArrayList<>();
+        List<CampaignStatusResponseDTO> registered = new ArrayList<>();
+        List<CampaignStatusResponseDTO> ended = new ArrayList<>();
+        List<CampaignStatus> all = campaignStatusRepository.findByUserAndIsActiveTrue(user);
+        for (CampaignStatus status : all) {
+            switch (status.getStatus()) {
+                case APPLY:
+                    apply.add(toDTO(status));
+                    break;
+                case SELECTED:
+                    selected.add(toDTO(status));
+                    break;
+                case REGISTERED:
+                    registered.add(toDTO(status));
+                    break;
+                case ENDED:
+                    ended.add(toDTO(status));
+                    break;
+                default:
+                    break;
+            }
+        }
+        // 1. 발표일 기준 정렬
+        apply.sort(Comparator.comparing(
+            CampaignStatusResponseDTO::getReviewerAnnouncement,
+            Comparator.nullsLast(Comparator.reverseOrder())
+        ));
+        // 2. 콘텐츠 제출 종료일 기준 정렬
+        selected.sort(Comparator.comparing(
+            CampaignStatusResponseDTO::getContentSubmissionEnd,
+            Comparator.nullsLast(Comparator.reverseOrder())
+        ));
+        // 3. 콘텐츠 제출 종료일 기준 정렬
+        registered.sort(Comparator.comparing(
+            CampaignStatusResponseDTO::getContentSubmissionEnd,
+            Comparator.nullsLast(Comparator.reverseOrder())
+        ));
+        // 4. 결과 발표일 기준 정렬
+        ended.sort(Comparator.comparing(
+            CampaignStatusResponseDTO::getResultAnnouncement,
+            Comparator.nullsLast(Comparator.reverseOrder())
+        ));
+        Map<String, Long> count = new HashMap<>();
+        count.put("apply", (long) apply.size());
+        count.put("selected", (long) selected.size());
+        count.put("registered", (long) registered.size());
+        count.put("ended", (long) ended.size());
+        return CampaignStatusListResponseDTO.builder()
+                .apply(apply)
+                .selected(selected)
+                .registered(registered)
+                .ended(ended)
+                .count(count)
+                .build();
+    }
+
+    private CampaignStatusResponseDTO toDTO(CampaignStatus status) {
+        String reviewerAnnouncementStatus = null;
+        switch (status.getStatus()) {
+            case APPLY:
+                reviewerAnnouncementStatus = CampaignStatusResponseDTO.getStatusMessage(status.getCampaign().getReviewerAnnouncement(), "apply");
+                break;
+            case SELECTED:
+                reviewerAnnouncementStatus = CampaignStatusResponseDTO.getStatusMessage(status.getCampaign().getContentSubmissionEnd(), "selected");
+                break;
+            case REGISTERED:
+                reviewerAnnouncementStatus = CampaignStatusResponseDTO.getStatusMessage(status.getCampaign().getContentSubmissionEnd(), "registered");
+                break;
+            case ENDED:
+                reviewerAnnouncementStatus = CampaignStatusResponseDTO.getStatusMessage(status.getCampaign().getResultAnnouncement(), "ended");
+                break;
+            default:
+                break;
+        }
+        return CampaignStatusResponseDTO.builder()
+                .id(status.getId())
+                .campaignId(status.getCampaign().getId())
+                .userId(status.getUser().getId())
+                .statusLabel(status.getStatus().getLabel())
+                .isActive(status.getIsActive())
+                .title(status.getCampaign().getTitle())
+                .detailUrl(status.getCampaign().getDetailUrl())
+                .imageUrl(status.getCampaign().getImageUrl())
+                .reviewerAnnouncement(status.getCampaign().getReviewerAnnouncement())
+                .reviewerAnnouncementStatus(reviewerAnnouncementStatus)
+                .applicantCount(status.getCampaign().getApplicantCount())
+                .recruitCount(status.getCampaign().getRecruitCount())
+                .snsPlatforms(com.example.cherrydan.campaign.dto.BookmarkResponseDTO.getPlatforms(status.getCampaign()))
+                .campaignPlatform(com.example.cherrydan.campaign.dto.BookmarkResponseDTO.getCampaignPlatformLabel(status.getCampaign().getSourceSite()))
+                .benefit(status.getCampaign().getBenefit())
+                .contentSubmissionEnd(status.getCampaign().getContentSubmissionEnd())
+                .resultAnnouncement(status.getCampaign().getResultAnnouncement())
+                .build();
+    }
+}

--- a/src/main/java/com/example/cherrydan/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/cherrydan/notice/controller/NoticeController.java
@@ -3,6 +3,7 @@ package com.example.cherrydan.notice.controller;
 import com.example.cherrydan.common.response.ApiResponse;
 import com.example.cherrydan.notice.dto.NoticeResponseDTO;
 import com.example.cherrydan.notice.service.NoticeService;
+import com.example.cherrydan.notice.service.NoticeBannerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import com.example.cherrydan.notice.dto.NoticeBannerResponseDTO;
 
 @RestController
 @RequestMapping("/api/notices")
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class NoticeController {
 
     private final NoticeService noticeService;
+    private final NoticeBannerService noticeBannerService;
 
     @Operation(summary = "공지사항 목록 조회")
     @GetMapping
@@ -39,4 +43,10 @@ public class NoticeController {
         NoticeResponseDTO notice = noticeService.incrementEmpathyCount(id);
         return ResponseEntity.ok(ApiResponse.success("공감이 반영되었습니다.", notice));
     }
-} 
+
+    @GetMapping("/banners")
+    public ResponseEntity<ApiResponse<List<NoticeBannerResponseDTO>>> getBanners() {
+        List<NoticeBannerResponseDTO> banners = noticeBannerService.getActiveBanners();
+        return ResponseEntity.ok(ApiResponse.success("배너 목록 조회가 완료되었습니다.", banners));
+    }
+}

--- a/src/main/java/com/example/cherrydan/notice/domain/NoticeBanner.java
+++ b/src/main/java/com/example/cherrydan/notice/domain/NoticeBanner.java
@@ -1,0 +1,33 @@
+package com.example.cherrydan.notice.domain;
+
+import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.EntityListeners;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import com.example.cherrydan.common.entity.BaseTimeEntity;
+
+@Entity
+@Table(name = "notice_banner")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class NoticeBanner extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String imageUrl;
+    private String bannerType; // NOTICE, EVENT, AD 등
+    private String linkType;   // INTERNAL, EXTERNAL
+    private Long targetId;     // 내부 이동용(상세 id)
+    private String targetUrl;  // 외부 이동용(광고 url)
+    private Boolean isActive;
+} 

--- a/src/main/java/com/example/cherrydan/notice/dto/NoticeBannerResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/notice/dto/NoticeBannerResponseDTO.java
@@ -1,0 +1,22 @@
+package com.example.cherrydan.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoticeBannerResponseDTO {
+    private Long id;
+    private String title;
+    private String imageUrl;
+    private String bannerType; // NOTICE, EVENT, AD 등
+    private String linkType;   // INTERNAL, EXTERNAL
+    private Long targetId;     // 내부 이동용(상세 id)
+    private String targetUrl;  // 외부 이동용(광고 url)
+    private LocalDateTime updatedAt;
+} 

--- a/src/main/java/com/example/cherrydan/notice/dto/NoticeResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/notice/dto/NoticeResponseDTO.java
@@ -1,4 +1,3 @@
-// src/main/java/com/example/cherrydan/notice/dto/NoticeResponse.java
 package com.example.cherrydan.notice.dto;
 
 import com.example.cherrydan.notice.domain.Notice;

--- a/src/main/java/com/example/cherrydan/notice/repository/NoticeBannerRepository.java
+++ b/src/main/java/com/example/cherrydan/notice/repository/NoticeBannerRepository.java
@@ -1,0 +1,9 @@
+package com.example.cherrydan.notice.repository;
+
+import com.example.cherrydan.notice.domain.NoticeBanner;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface NoticeBannerRepository extends JpaRepository<NoticeBanner, Long> {
+    List<NoticeBanner> findByIsActiveTrue();
+} 

--- a/src/main/java/com/example/cherrydan/notice/service/NoticeBannerService.java
+++ b/src/main/java/com/example/cherrydan/notice/service/NoticeBannerService.java
@@ -1,0 +1,8 @@
+package com.example.cherrydan.notice.service;
+
+import com.example.cherrydan.notice.dto.NoticeBannerResponseDTO;
+import java.util.List;
+
+public interface NoticeBannerService {
+    List<NoticeBannerResponseDTO> getActiveBanners();
+} 

--- a/src/main/java/com/example/cherrydan/notice/service/NoticeBannerServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/notice/service/NoticeBannerServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.cherrydan.notice.service;
+
+import com.example.cherrydan.notice.domain.NoticeBanner;
+import com.example.cherrydan.notice.dto.NoticeBannerResponseDTO;
+import com.example.cherrydan.notice.repository.NoticeBannerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeBannerServiceImpl implements NoticeBannerService {
+    private final NoticeBannerRepository noticeBannerRepository;
+
+    @Override
+    public List<NoticeBannerResponseDTO> getActiveBanners() {
+        List<NoticeBanner> banners = noticeBannerRepository.findByIsActiveTrue();
+        return banners.stream().map(banner -> NoticeBannerResponseDTO.builder()
+                .id(banner.getId())
+                .title(banner.getTitle())
+                .imageUrl(banner.getImageUrl())
+                .bannerType(banner.getBannerType())
+                .linkType(banner.getLinkType())
+                .targetId(banner.getTargetId())
+                .targetUrl(banner.getTargetUrl())
+                .build())
+            .collect(Collectors.toList());
+    }
+} 

--- a/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
@@ -49,6 +49,12 @@ public class SecurityConfig {
                         .requestMatchers("/apple-login-test.html").permitAll()
                         // OAuth2 관련 경로
                         .requestMatchers("/api/oauth2/**", "/api/login/oauth2/**").permitAll()
+                        // 캠페인 관련 경로
+                        .requestMatchers("/api/campaigns/types").permitAll()
+                        .requestMatchers("/api/campaigns/sns-platforms").permitAll()
+                        .requestMatchers("/api/campaigns/campaign-platforms").permitAll()
+                        // 공지사항/홈 광고 배너 관련 경로
+                        .requestMatchers("/api/notices/**").permitAll()
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
# Pull Request: [feature] #15 내 체험단 & 홈 광고 배너 API 개발

## 변경 사항 요약
- 내 체험단 상태 조회, 생성, 수정, 삭제 API 추가
- 내 체험단 노출 팝업 조회 API 추가
- 홈 배너 광고 목록 조회 API 추가

## 변경 이유
#15 

## 테스트 방법
단위 테스트: 개발하고 추가하겠슴당
수동 테스트: postman으로 테스트 진행했습니당

## 참고 사항
- `/api/campaigns/my-status/popup` Swagger 응답 양식이 의도한 대로 안나오는데 요거 SOS 요청합니다 갓뱅주씨~~
- 캠페인 검색 API는 아직 못만들었습니다 흙흙
- 비밀인데 크롤링 할 때 주소 필터링하는 로직 아직 추가 못했어요🤓