### PR TITLE
[Feature] #39 캠페인 카테고리 및 키워드 검색 API 개발

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignCategoryController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignCategoryController.java
@@ -1,0 +1,54 @@
+package com.example.cherrydan.campaign.controller;
+
+import com.example.cherrydan.campaign.dto.CampaignListResponseDTO;
+import com.example.cherrydan.campaign.service.CampaignCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/campaigns/categories")
+@RequiredArgsConstructor
+public class CampaignCategoryController {
+
+    private final CampaignCategoryService campaignCategoryService;
+
+    /**
+     * 카테고리별 캠페인 검색 API
+     * ex) /api/campaigns/categories/search?regionGroup=서울&product=식품
+     */
+    @GetMapping("/search")
+    public CampaignListResponseDTO searchByCategory(
+        @RequestParam(required = false) String regionGroup,
+        @RequestParam(required = false) String subRegion,
+        @RequestParam(required = false) String local,
+        @RequestParam(required = false) String product,
+        @RequestParam(required = false) String reporter,
+        @RequestParam(required = false) String snsPlatform,
+        @RequestParam(required = false) String experiencePlatform,
+        @RequestParam(required = false, defaultValue = "popular") String sort,
+        @RequestParam(required = false, defaultValue = "0") int page,
+        @RequestParam(required = false, defaultValue = "20") int size
+    ) {
+        Pageable pageable = createPageable(sort, page, size);
+
+        return campaignCategoryService.searchByCategory(regionGroup, subRegion, local, product, reporter, snsPlatform, experiencePlatform, pageable);
+    }
+
+    private Pageable createPageable(String sort, int page, int size) {
+        switch (sort) {
+            case "popular":
+                return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "competitionRate"));
+            case "latest":
+                return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "applyStart"));
+            case "deadline":
+                return PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "applyEnd"));
+            case "low_competition":
+                return PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "competitionRate"));
+            default:
+                return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "competitionRate"));
+        }
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignCategoryController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignCategoryController.java
@@ -7,10 +7,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/campaigns/categories")
 @RequiredArgsConstructor
+@Tag(name = "Campaign Category API", description = "카테고리별 캠페인 검색 API")
 public class CampaignCategoryController {
 
     private final CampaignCategoryService campaignCategoryService;
@@ -19,17 +23,33 @@ public class CampaignCategoryController {
      * 카테고리별 캠페인 검색 API
      * ex) /api/campaigns/categories/search?regionGroup=서울&product=식품
      */
+    @Operation(
+        summary = "카테고리별 캠페인 검색",
+        description = "여러 카테고리(지역, 제품, 기자단, SNS, 체험단 플랫폼 등) 조건으로 캠페인 목록을 검색합니다.\n\n"
+            + "regionGroup, subRegion, local, product, reporter, snsPlatform, experiencePlatform 중 원하는 조건만 조합해서 검색할 수 있습니다.\n"
+            + "정렬(sort): popular(인기순), latest(최신순), deadline(마감임박순), low_competition(경쟁률 낮은순)"
+    )
     @GetMapping("/search")
     public CampaignListResponseDTO searchByCategory(
+        @Parameter(description = "지역 그룹 (예: seoul, gyeonggi_incheon 등)")
         @RequestParam(required = false) String regionGroup,
+        @Parameter(description = "하위 지역 (예: gangnam_nonhyeon 등)")
         @RequestParam(required = false) String subRegion,
+        @Parameter(description = "로컬 카테고리 (예: restaurant, beauty 등)")
         @RequestParam(required = false) String local,
+        @Parameter(description = "제품 카테고리 (예: food, beauty 등)")
         @RequestParam(required = false) String product,
+        @Parameter(description = "기자단 여부 (예: reporter)")
         @RequestParam(required = false) String reporter,
+        @Parameter(description = "SNS 플랫폼 (예: blog, youtube, insta, tiktok, etc)")
         @RequestParam(required = false) String snsPlatform,
+        @Parameter(description = "체험단 플랫폼 (예: chvu, revu 등)")
         @RequestParam(required = false) String experiencePlatform,
+        @Parameter(description = "정렬 기준 (popular, latest, deadline, low_competition)", example = "popular")
         @RequestParam(required = false, defaultValue = "popular") String sort,
+        @Parameter(description = "페이지 번호", example = "0")
         @RequestParam(required = false, defaultValue = "0") int page,
+        @Parameter(description = "페이지 크기", example = "20")
         @RequestParam(required = false, defaultValue = "20") int size
     ) {
         Pageable pageable = createPageable(sort, page, size);

--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignController.java
@@ -96,10 +96,17 @@ public class CampaignController {
         return campaignService.getCampaignsBySnsPlatform(snsPlatformType, sort, pageable);
     }
 
+    @Operation(
+        summary = "키워드 기반 캠페인 검색",
+        description = "title에 키워드가 포함된 캠페인(지역/제품 타입, is_active=1)만 검색합니다."
+    )
     @GetMapping("/search")
     public CampaignListResponseDTO searchCampaignsByKeyword(
+        @Parameter(description = "검색 키워드 (title에 포함)")
         @RequestParam String keyword,
+        @Parameter(description = "페이지 번호", example = "0")
         @RequestParam(defaultValue = "0") int page,
+        @Parameter(description = "페이지 크기", example = "20")
         @RequestParam(defaultValue = "20") int size
     ) {
         Pageable pageable = PageRequest.of(page, size);

--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignController.java
@@ -96,6 +96,16 @@ public class CampaignController {
         return campaignService.getCampaignsBySnsPlatform(snsPlatformType, sort, pageable);
     }
 
+    @GetMapping("/search")
+    public CampaignListResponseDTO searchCampaignsByKeyword(
+        @RequestParam String keyword,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return campaignService.searchByKeyword(keyword, pageable);
+    }
+
     private Pageable createPageable(String sort, int page, int size) {
         switch (sort) {
             case "popular":

--- a/src/main/java/com/example/cherrydan/campaign/domain/Campaign.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/Campaign.java
@@ -96,7 +96,7 @@ public class Campaign extends BaseTimeEntity {
     @ColumnDefault("0")
     private Boolean etc;
 
-    @Enumerated(EnumType.ORDINAL)
+    @Convert(converter = CampaignTypeConverter.class)
     @Column(name = "campaign_type")
     private CampaignType campaignType;
 

--- a/src/main/java/com/example/cherrydan/campaign/domain/Campaign.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/Campaign.java
@@ -111,4 +111,10 @@ public class Campaign extends BaseTimeEntity {
 
     @Column(name = "product_category")
     private Integer productCategory;
+
+    @Column(name = "region_group")
+    private Integer regionGroup;
+
+    @Column(name = "region_detail")
+    private Integer regionDetail;
 }

--- a/src/main/java/com/example/cherrydan/campaign/domain/CampaignType.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/CampaignType.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum CampaignType {
-    PRODUCT(1, "제품"),
-    REGION(2, "지역"),
+    REGION(1, "지역"),
+    PRODUCT(2, "제품"),
     REPORTER(3, "기자단"),
     ETC(4, "기타");
 

--- a/src/main/java/com/example/cherrydan/campaign/domain/CampaignTypeConverter.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/CampaignTypeConverter.java
@@ -1,0 +1,17 @@
+package com.example.cherrydan.campaign.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class CampaignTypeConverter implements AttributeConverter<CampaignType, Integer> {
+    @Override
+    public Integer convertToDatabaseColumn(CampaignType attribute) {
+        return attribute != null ? attribute.getCode() : null;
+    }
+
+    @Override
+    public CampaignType convertToEntityAttribute(Integer dbData) {
+        return dbData != null ? CampaignType.fromCode(dbData) : null;
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/domain/LocalCategory.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/LocalCategory.java
@@ -1,0 +1,37 @@
+package com.example.cherrydan.campaign.domain;
+
+import com.example.cherrydan.common.util.StringUtil;
+
+public enum LocalCategory {
+    RESTAURANT(1, "맛집", "restaurant"),
+    BEAUTY(2, "뷰티", "beauty"),
+    ACCOMMODATION(3, "숙박", "accommodation"),
+    CULTURE(4, "문화", "culture"),
+    DELIVERY(5, "배달", "delivery"),
+    TAKEOUT(6, "포장", "takeout"),
+    ETC(99, "기타", "etc");
+
+    private final int code;
+    private final String label;
+    private final String engLabel;
+
+    LocalCategory(int code, String label, String engLabel) {
+        this.code = code;
+        this.label = label;
+        this.engLabel = engLabel;
+    }
+
+    public int getCode() { return code; }
+    public String getLabel() { return label; }
+    public String getEngLabel() { return engLabel; }
+
+    public static LocalCategory fromString(String value) {
+        String v = StringUtil.normalize(value);
+        for (LocalCategory c : values()) {
+            if (c.engLabel.equalsIgnoreCase(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException("Unknown local category: " + value);
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/domain/ProductCategory.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/ProductCategory.java
@@ -1,0 +1,41 @@
+package com.example.cherrydan.campaign.domain;
+
+import com.example.cherrydan.common.util.StringUtil;
+
+public enum ProductCategory {
+    FOOD(1, "식품", "food"),
+    LIVING(2, "생활", "living"),
+    DIGITAL(3, "디지털", "digital"),
+    BEAUTY_FASHION(4, "뷰티/패션", "beauty_fashion"),
+    PET(5, "반려동물", "pet"),
+    KIDS(6, "유아동", "kids"),
+    BOOK(7, "도서", "book"),
+    RESTAURANT(8, "맛집", "restaurant"),
+    TRAVEL(9, "여행", "travel"),
+    SERVICE(10, "서비스", "service"),
+    ETC(99, "기타", "etc");
+
+    private final int code;
+    private final String label;
+    private final String engLabel;
+
+    ProductCategory(int code, String label, String engLabel) {
+        this.code = code;
+        this.label = label;
+        this.engLabel = engLabel;
+    }
+
+    public int getCode() { return code; }
+    public String getLabel() { return label; }
+    public String getEngLabel() { return engLabel; }
+
+    public static ProductCategory fromString(String value) {
+        String v = StringUtil.normalize(value);
+        for (ProductCategory c : values()) {
+            if (c.engLabel.equalsIgnoreCase(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException("Unknown product category: " + value);
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/domain/RegionGroup.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/RegionGroup.java
@@ -1,0 +1,151 @@
+package com.example.cherrydan.campaign.domain;
+
+import java.util.*;
+
+public enum RegionGroup {
+    서울(1, "서울", "seoul", Arrays.asList(
+        new SubRegion(1, "교대/사당", "gyodae_sadang"),
+        new SubRegion(2, "압구정/신사", "apgujeong_sinsa"),
+        new SubRegion(3, "강남/논현", "gangnam_nonhyeon"),
+        new SubRegion(4, "삼성/선릉", "samseong_seolleung"),
+        new SubRegion(5, "송파/잠실", "songpa_jamsil"),
+        new SubRegion(6, "강동/천호", "gangdong_cheongho"),
+        new SubRegion(7, "건대/왕십리", "geondae_wangsimni"),
+        new SubRegion(8, "홍대/마포", "hongdae_mapo"),
+        new SubRegion(9, "강서/목동", "gangseo_mokdong"),
+        new SubRegion(10, "노원/강북/도봉", "nowon_gangbuk_dobong"),
+        new SubRegion(11, "명동/이태원", "myeongdong_itaewon"),
+        new SubRegion(12, "수유/동대문/중랑", "suyu_dongdaemun_jungnang"),
+        new SubRegion(13, "신촌/이대/은평", "sinchon_ewha_eunpyeong"),
+        new SubRegion(14, "여의도/영등포", "yeouido_yeongdeungpo"),
+        new SubRegion(15, "종로/대학로/성북", "jongno_daehakro_seongbuk"),
+        new SubRegion(16, "관악/신림", "gwanak_sillim"),
+        new SubRegion(17, "구로/금천", "guro_geumcheon"),
+        new SubRegion(18, "기타", "etc")
+    )),
+    경기_인천(2, "경기/인천", "gyeonggi_incheon", Arrays.asList(
+        new SubRegion(19, "남양주/구리/하남", "namyangju_guri_hanam"),
+        new SubRegion(20, "일산/파주", "ilsan_paju"),
+        new SubRegion(21, "안양/안산/광명", "anam_ansan_gwangmyeong"),
+        new SubRegion(22, "용인/성남/수원", "yongin_sangnam_suwon"),
+        new SubRegion(23, "화성", "hwaseong"),
+        new SubRegion(24, "인천/부천", "incheon_buchon"),
+        new SubRegion(25, "기타", "etc")
+    )),
+    강원(3, "강원", "gangwon", Arrays.asList(
+        new SubRegion(26, "속초/양양/강릉", "sokcho_yangyang_gangryong"),
+        new SubRegion(27, "춘천/홍천/원주", "chuncheon_hongcheon_wonju"),
+        new SubRegion(28, "기타", "etc")
+    )),
+    대전_충청(4, "대전/충청", "daejeon_chungcheong", Arrays.asList(
+        new SubRegion(29, "대전/세종", "daejeon_sejong"),
+        new SubRegion(30, "충북", "chungbuk"),
+        new SubRegion(31, "충남", "chungnam")
+    )),
+    대구_경북(5, "대구/경북", "daegu_gyeongbuk", Arrays.asList(
+        new SubRegion(32, "대구", "daegu"),
+        new SubRegion(33, "경북", "gyeongbuk")
+    )),
+    부산_경남(6, "부산/경남", "busan_gyeongnam", Arrays.asList(
+        new SubRegion(34, "부산", "busan"),
+        new SubRegion(35, "울산", "ulsan"),
+        new SubRegion(36, "경남", "gyeongnam")
+    )),
+    광주_전라(7, "광주/전라", "gwangju_jeolla", Arrays.asList(
+        new SubRegion(37, "광주", "gwangju"),
+        new SubRegion(38, "전북", "jeonbuk"),
+        new SubRegion(39, "전남", "jeonnam")
+    )),
+    제주(8, "제주", "jeju", Arrays.asList(
+        new SubRegion(40, "제주", "jeju")
+    ));
+
+    private final int code;
+    private final String label;
+    private final String codeName;
+    private final List<SubRegion> subRegions;
+
+    RegionGroup(int code, String label, String codeName, List<SubRegion> subRegions) {
+        this.code = code;
+        this.label = label;
+        this.codeName = codeName;
+        this.subRegions = subRegions;
+    }
+
+    public int getCode() { return code; }
+    public String getLabel() { return label; }
+    public String getCodeName() { return codeName; }
+    public List<SubRegion> getSubRegions() { return subRegions; }
+
+    public static RegionGroup fromCode(int code) {
+        for (RegionGroup r : values()) {
+            if (r.code == code) return r;
+        }
+        throw new IllegalArgumentException("Unknown code: " + code);
+    }
+
+    public static RegionGroup fromLabel(String label) {
+        for (RegionGroup r : values()) {
+            if (r.label.equals(label)) return r;
+        }
+        throw new IllegalArgumentException("Unknown label: " + label);
+    }
+
+    /**
+     * 하위 지역 codeName으로 RegionGroup, SubRegion 코드 찾기
+     * ex) "gyodae_sadang" → (RegionGroup.서울, SubRegion(1, "교대/사당", "gyodae_sadang"))
+     */
+    public static Optional<RegionGroupSubRegionMatch> findBySubRegionCodeName(String codeName) {
+        for (RegionGroup r : values()) {
+            for (SubRegion sub : r.subRegions) {
+                if (sub.getCodeName().equalsIgnoreCase(codeName)) {
+                    return Optional.of(new RegionGroupSubRegionMatch(r, sub));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static RegionGroup fromCodeName(String codeName) {
+        for (RegionGroup r : values()) {
+            if (r.codeName.equalsIgnoreCase(codeName)) {
+                return r;
+            }
+        }
+        throw new IllegalArgumentException("Unknown codeName: " + codeName);
+    }
+
+    // 하위 지역 클래스
+    public static class SubRegion {
+        private final int code;
+        private final String label;
+        private final String codeName;
+        public SubRegion(int code, String label, String codeName) {
+            this.code = code;
+            this.label = label;
+            this.codeName = codeName;
+        }
+        public int getCode() { return code; }
+        public String getLabel() { return label; }
+        public String getCodeName() { return codeName; }
+    }
+
+    // 하위 지역 매칭용 클래스
+    public static class RegionGroupSubRegionMatch {
+        private final RegionGroup regionGroup;
+        private final SubRegion subRegion;
+
+        public RegionGroupSubRegionMatch(RegionGroup regionGroup, SubRegion subRegion) {
+            this.regionGroup = regionGroup;
+            this.subRegion = subRegion;
+        }
+
+        public RegionGroup getRegionGroup() {
+            return regionGroup;
+        }
+
+        public SubRegion getSubRegion() {
+            return subRegion;
+        }
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
@@ -62,4 +62,41 @@ public class CampaignResponseDTO {
             return "오늘 발표";
         }
     }
+
+    public static String toPlatformLabel(String code) {
+        if (code == null) return null;
+        String normalized = com.example.cherrydan.common.util.StringUtil.normalize(code);
+        try {
+            return com.example.cherrydan.campaign.domain.CampaignPlatformType.fromCode(normalized).getLabel();
+        } catch (IllegalArgumentException e) {
+            return normalized;
+        }
+    }
+
+    public static CampaignResponseDTO fromEntity(com.example.cherrydan.campaign.domain.Campaign campaign) {
+        return CampaignResponseDTO.builder()
+            .id(campaign.getId())
+            .title(campaign.getTitle())
+            .detailUrl(campaign.getDetailUrl())
+            .benefit(campaign.getBenefit())
+            .reviewerAnnouncementStatus(getReviewerAnnouncementStatus(campaign.getReviewerAnnouncement()))
+            .applicantCount(campaign.getApplicantCount())
+            .recruitCount(campaign.getRecruitCount())
+            .sourceSite(toPlatformLabel(campaign.getSourceSite()))
+            .imageUrl(campaign.getImageUrl())
+            .youtube(campaign.getYoutube())
+            .shorts(campaign.getShorts())
+            .insta(campaign.getInsta())
+            .reels(campaign.getReels())
+            .blog(campaign.getBlog())
+            .clip(campaign.getClip())
+            .tiktok(campaign.getTiktok())
+            .etc(campaign.getEtc())
+            .campaignType(campaign.getCampaignType())
+            .address(campaign.getAddress())
+            .competitionRate(campaign.getCompetitionRate())
+            .localCategory(campaign.getLocalCategory())
+            .productCategory(campaign.getProductCategory())
+            .build();
+    }
 } 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignCategoryService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignCategoryService.java
@@ -1,0 +1,17 @@
+package com.example.cherrydan.campaign.service;
+
+import com.example.cherrydan.campaign.dto.CampaignListResponseDTO;
+import org.springframework.data.domain.Pageable;
+
+public interface CampaignCategoryService {
+    CampaignListResponseDTO searchByCategory(
+        String regionGroup,
+        String subRegion,
+        String local,
+        String product,
+        String reporter,
+        String snsPlatform,
+        String experiencePlatform,
+        Pageable pageable
+    );
+} 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignCategoryServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignCategoryServiceImpl.java
@@ -7,13 +7,14 @@ import com.example.cherrydan.campaign.repository.CampaignRepository;
 import com.example.cherrydan.campaign.domain.RegionGroup;
 import com.example.cherrydan.common.exception.ErrorMessage;
 import com.example.cherrydan.common.exception.CampaignException;
+import com.example.cherrydan.common.util.StringUtil;
+import com.example.cherrydan.campaign.domain.CampaignPlatformType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import jakarta.persistence.criteria.Predicate;
-import com.example.cherrydan.common.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -148,29 +149,6 @@ public class CampaignCategoryServiceImpl implements CampaignCategoryService {
     }
 
     private CampaignResponseDTO toDTO(Campaign campaign) {
-        return CampaignResponseDTO.builder()
-                .id(campaign.getId())
-                .title(campaign.getTitle())
-                .detailUrl(campaign.getDetailUrl())
-                .benefit(campaign.getBenefit())
-                .reviewerAnnouncementStatus(CampaignResponseDTO.getReviewerAnnouncementStatus(campaign.getReviewerAnnouncement()))
-                .applicantCount(campaign.getApplicantCount())
-                .recruitCount(campaign.getRecruitCount())
-                .sourceSite(campaign.getSourceSite())
-                .imageUrl(campaign.getImageUrl())
-                .youtube(campaign.getYoutube())
-                .shorts(campaign.getShorts())
-                .insta(campaign.getInsta())
-                .reels(campaign.getReels())
-                .blog(campaign.getBlog())
-                .clip(campaign.getClip())
-                .tiktok(campaign.getTiktok())
-                .etc(campaign.getEtc())
-                .campaignType(campaign.getCampaignType())
-                .address(campaign.getAddress())
-                .competitionRate(campaign.getCompetitionRate())
-                .localCategory(campaign.getLocalCategory())
-                .productCategory(campaign.getProductCategory())
-                .build();
+        return com.example.cherrydan.campaign.dto.CampaignResponseDTO.fromEntity(campaign);
     }
 } 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignCategoryServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignCategoryServiceImpl.java
@@ -1,0 +1,176 @@
+package com.example.cherrydan.campaign.service;
+
+import com.example.cherrydan.campaign.domain.Campaign;
+import com.example.cherrydan.campaign.dto.CampaignListResponseDTO;
+import com.example.cherrydan.campaign.dto.CampaignResponseDTO;
+import com.example.cherrydan.campaign.repository.CampaignRepository;
+import com.example.cherrydan.campaign.domain.RegionGroup;
+import com.example.cherrydan.common.exception.ErrorMessage;
+import com.example.cherrydan.common.exception.CampaignException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import jakarta.persistence.criteria.Predicate;
+import com.example.cherrydan.common.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.example.cherrydan.campaign.domain.CampaignType;
+import com.example.cherrydan.campaign.domain.LocalCategory;
+import com.example.cherrydan.campaign.domain.ProductCategory;
+
+@Service
+@RequiredArgsConstructor
+public class CampaignCategoryServiceImpl implements CampaignCategoryService {
+
+    private final CampaignRepository campaignRepository;
+
+    @Override
+    public CampaignListResponseDTO searchByCategory(String regionGroup, String subRegion, String local, String product, String reporter, String snsPlatform, String experiencePlatform, Pageable pageable) {
+        Specification<Campaign> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.isTrue(root.get("isActive")));
+
+            // regionGroup, subRegion 조건 처리
+            boolean hasRegionGroup = regionGroup != null && !regionGroup.isEmpty();
+            boolean hasSubRegion = subRegion != null && !subRegion.isEmpty();
+
+            if (hasRegionGroup) {
+                RegionGroup regionGroupEnum;
+                try {
+                    regionGroupEnum = RegionGroup.fromCodeName(regionGroup);
+                } catch (IllegalArgumentException e) {
+                    throw new CampaignException(ErrorMessage.CAMPAIGN_REGION_GROUP_NOT_FOUND);
+                }
+                predicates.add(cb.equal(root.get("regionGroup"), regionGroupEnum.getCode()));
+            }
+            if (hasSubRegion) {
+                RegionGroup.RegionGroupSubRegionMatch match = RegionGroup.findBySubRegionCodeName(subRegion)
+                        .orElseThrow(() -> new CampaignException(ErrorMessage.CAMPAIGN_REGION_DETAIL_NOT_FOUND));
+                predicates.add(cb.equal(root.get("regionDetail"), match.getSubRegion().getCode()));
+            }
+
+            List<Predicate> typePredicates = new ArrayList<>();
+
+            // 지역 카테고리 조건 처리
+            if (local != null && !local.isEmpty() && !local.equalsIgnoreCase("all")) {
+                try {
+                    int code = LocalCategory.fromString(local).getCode();
+                    typePredicates.add(cb.and(
+                        cb.equal(root.get("campaignType"), CampaignType.REGION),
+                        cb.equal(root.get("localCategory"), code)
+                    ));
+                } catch (IllegalArgumentException e) {
+                    throw new CampaignException(ErrorMessage.CAMPAIGN_REGION_DETAIL_NOT_FOUND);
+                }
+            }
+
+            // 제품 카테고리 조건 처리
+            if (product != null && !product.isEmpty() && !product.equalsIgnoreCase("all")) {
+                try {
+                    int code = ProductCategory.fromString(product).getCode();
+                    typePredicates.add(cb.and(
+                        cb.equal(root.get("campaignType"), CampaignType.PRODUCT),
+                        cb.equal(root.get("productCategory"), code)
+                    ));
+                } catch (IllegalArgumentException e) {
+                    throw new CampaignException(ErrorMessage.CAMPAIGN_PRODUCT_CATEGORY_NOT_FOUND);
+                }
+            }
+
+            // 기자단 카테고리 조건 처리
+            if (reporter != null && !reporter.isEmpty()) {
+                typePredicates.add(cb.equal(root.get("campaignType"), CampaignType.REPORTER));
+            }
+
+            // typePredicates가 비어있지 않으면 OR로 묶어서 predicates에 추가
+            if (!typePredicates.isEmpty()) {
+                predicates.add(cb.or(typePredicates.toArray(new Predicate[0])));
+            }
+
+            // SNS 플랫폼 조건 처리
+            String snsPlatformNorm = StringUtil.normalize(snsPlatform);
+            if (snsPlatformNorm != null && !snsPlatformNorm.isEmpty() && !snsPlatformNorm.equals("all")) {
+                switch (snsPlatformNorm) {
+                    case "blog":
+                        predicates.add(cb.or(
+                            cb.isTrue(root.get("blog")),
+                            cb.isTrue(root.get("clip"))
+                        ));
+                        break;
+                    case "youtube":
+                        predicates.add(cb.or(
+                            cb.isTrue(root.get("youtube")),
+                            cb.isTrue(root.get("shorts"))
+                        ));
+                        break;
+                    case "insta":
+                        predicates.add(cb.or(
+                            cb.isTrue(root.get("insta")),
+                            cb.isTrue(root.get("reels"))
+                        ));
+                        break;
+                    case "tiktok":
+                        predicates.add(cb.isTrue(root.get("tiktok")));
+                        break;
+                    case "etc":
+                        predicates.add(cb.isTrue(root.get("etc")));
+                        break;
+                }
+            }
+
+            // 체험단 플랫폼 조건 처리
+            String experiencePlatformNorm = StringUtil.normalize(experiencePlatform);
+            if (experiencePlatformNorm != null && !experiencePlatformNorm.isEmpty()) {
+                predicates.add(cb.equal(root.get("sourceSite"), experiencePlatformNorm));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+
+        Page<Campaign> campaigns = campaignRepository.findAll(spec, pageable);
+        List<CampaignResponseDTO> content = campaigns.getContent().stream()
+                .map(this::toDTO)
+                .collect(Collectors.toList());
+        return CampaignListResponseDTO.builder()
+                .content(content)
+                .page(campaigns.getNumber())
+                .size(campaigns.getSize())
+                .totalElements(campaigns.getTotalElements())
+                .totalPages(campaigns.getTotalPages())
+                .hasNext(campaigns.hasNext())
+                .hasPrevious(campaigns.hasPrevious())
+                .build();
+    }
+
+    private CampaignResponseDTO toDTO(Campaign campaign) {
+        return CampaignResponseDTO.builder()
+                .id(campaign.getId())
+                .title(campaign.getTitle())
+                .detailUrl(campaign.getDetailUrl())
+                .benefit(campaign.getBenefit())
+                .reviewerAnnouncementStatus(CampaignResponseDTO.getReviewerAnnouncementStatus(campaign.getReviewerAnnouncement()))
+                .applicantCount(campaign.getApplicantCount())
+                .recruitCount(campaign.getRecruitCount())
+                .sourceSite(campaign.getSourceSite())
+                .imageUrl(campaign.getImageUrl())
+                .youtube(campaign.getYoutube())
+                .shorts(campaign.getShorts())
+                .insta(campaign.getInsta())
+                .reels(campaign.getReels())
+                .blog(campaign.getBlog())
+                .clip(campaign.getClip())
+                .tiktok(campaign.getTiktok())
+                .etc(campaign.getEtc())
+                .campaignType(campaign.getCampaignType())
+                .address(campaign.getAddress())
+                .competitionRate(campaign.getCompetitionRate())
+                .localCategory(campaign.getLocalCategory())
+                .productCategory(campaign.getProductCategory())
+                .build();
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignService.java
@@ -21,4 +21,6 @@ public interface CampaignService {
     );
     
     CampaignListResponseDTO getCampaignsByCampaignPlatform(CampaignPlatformType campaignPlatformType, String sort, Pageable pageable);
+
+    CampaignListResponseDTO searchByKeyword(String keyword, Pageable pageable);
 } 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
@@ -143,29 +143,6 @@ public class CampaignServiceImpl implements CampaignService {
     }
 
     private CampaignResponseDTO toDTO(Campaign campaign) {
-        return CampaignResponseDTO.builder()
-            .id(campaign.getId())
-            .title(campaign.getTitle())
-            .detailUrl(campaign.getDetailUrl())
-            .benefit(campaign.getBenefit())
-            .reviewerAnnouncementStatus(CampaignResponseDTO.getReviewerAnnouncementStatus(campaign.getReviewerAnnouncement()))
-            .applicantCount(campaign.getApplicantCount())
-            .recruitCount(campaign.getRecruitCount())
-            .sourceSite(campaign.getSourceSite())
-            .imageUrl(campaign.getImageUrl())
-            .youtube(campaign.getYoutube())
-            .shorts(campaign.getShorts())
-            .insta(campaign.getInsta())
-            .reels(campaign.getReels())
-            .blog(campaign.getBlog())
-            .clip(campaign.getClip())
-            .tiktok(campaign.getTiktok())
-            .etc(campaign.getEtc())
-            .campaignType(campaign.getCampaignType())
-            .address(campaign.getAddress())
-            .competitionRate(campaign.getCompetitionRate())
-            .localCategory(campaign.getLocalCategory())
-            .productCategory(campaign.getProductCategory())
-            .build();
+        return CampaignResponseDTO.fromEntity(campaign);
     }
 } 

--- a/src/main/java/com/example/cherrydan/common/exception/CampaignException.java
+++ b/src/main/java/com/example/cherrydan/common/exception/CampaignException.java
@@ -1,0 +1,7 @@
+package com.example.cherrydan.common.exception;
+
+public class CampaignException extends BaseException {
+    public CampaignException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
@@ -14,6 +14,14 @@ public enum ErrorMessage {
     USER_EMAIL_ALREADY_EXISTS(BAD_REQUEST, "이미 사용 중인 이메일입니다."),
     USER_USERNAME_ALREADY_EXISTS(BAD_REQUEST, "이미 사용 중인 사용자 이름입니다."),
     USER_INVALID_CREDENTIALS(UNAUTHORIZED, "잘못된 이메일 또는 비밀번호입니다."),
+
+    // 캠페인 관련 에러
+    CAMPAIGN_REGION_GROUP_NOT_FOUND(NOT_FOUND, "존재하지 않는 대분류 지역명입니다."),
+    CAMPAIGN_REGION_DETAIL_NOT_FOUND(NOT_FOUND, "존재하지 않는 하위 지역명입니다."),
+    CAMPAIGN_PRODUCT_CATEGORY_NOT_FOUND(NOT_FOUND, "존재하지 않는 제품 카테고리입니다."),
+    CAMPAIGN_REPORTER_NOT_FOUND(NOT_FOUND, "존재하지 않는 기자단입니다."),
+    CAMPAIGN_SNS_NOT_FOUND(NOT_FOUND, "존재하지 않는 SNS 플랫폼입니다."),
+    CAMPAIGN_EXPERIENCE_PLATFORM_NOT_FOUND(NOT_FOUND, "존재하지 않는 체험단 플랫폼입니다."),
     
     // OAuth 관련 에러
     OAUTH_DUPLICATE_EMAIL(BAD_REQUEST, "이미 다른 소셜 계정으로 가입된 이메일입니다."),

--- a/src/main/java/com/example/cherrydan/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/cherrydan/common/exception/GlobalExceptionHandler.java
@@ -107,6 +107,17 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(errorMessage.getHttpStatus().value(), errorMessage.getMessage()));
     }
 
+    /**
+     * CampaignException 처리
+     */
+    @ExceptionHandler(CampaignException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCampaignException(CampaignException ex) {
+        ErrorMessage errorMessage = ex.getErrorMessage();
+        logger.error("CampaignException: {}", errorMessage.getMessage());
+        return ResponseEntity.status(errorMessage.getHttpStatus())
+                .body(ApiResponse.error(errorMessage.getHttpStatus().value(), errorMessage.getMessage()));
+    }
+
 
     /**
      * 유효성 검사 실패 예외 처리

--- a/src/main/java/com/example/cherrydan/common/util/StringUtil.java
+++ b/src/main/java/com/example/cherrydan/common/util/StringUtil.java
@@ -1,0 +1,7 @@
+package com.example.cherrydan.common.util;
+
+public class StringUtil {
+    public static String normalize(String value) {
+        return value == null ? null : value.trim().toLowerCase();
+    }
+} 


### PR DESCRIPTION
# Pull Request: [Feature] #39 캠페인 카테고리 및 키워드 검색 API 개발

## 변경 사항 요약
- 캠페인 카테고리 검색 API 추가
- 키워드 검색 API 추가
- Swagger 추가  

## 변경 이유
#39 

## 테스트 방법
- 단위 테스트 - 조건이 워낙 많아 꼭 추가.. 해야 합니다ㅎㅎ
- 수동 테스트 시나리오 - 포스트맨으로 테스트 했습니당


## 성능 영향 (선택 사항)
- 카테고리 검색 조건이 워낙 많아 성능 이슈 발생 가능성 ⭐️⭐️⭐️⭐️⭐️

## 참고 사항
- 카테고리 검색 시 Enum 관리를 어떻게 할지 고민을 많이 해봤는데 크흠 우선 아래 방법처럼 구현해 놓았습니다.
- 지역을 `RegionGroup(서울, 경기/인천 등)`, `subRegion(교대/사당, 압구정/신사 등)` 컬럼 2개 추가하고 이를 참조하도록 개발했습니다!
(크롤링 작업 아직 못한건 안비밀ㄹ...)
 
```
    서울(1, "서울", "seoul", Arrays.asList(
        new SubRegion(1, "교대/사당", "gyodae_sadang"),
        new SubRegion(2, "압구정/신사", "apgujeong_sinsa"),
        new SubRegion(3, "강남/논현", "gangnam_nonhyeon"),
        new SubRegion(4, "삼성/선릉", "samseong_seolleung"),
        new SubRegion(5, "송파/잠실", "songpa_jamsil"),
        new SubRegion(6, "강동/천호", **"gangdong_cheongho"),
        .
        .
        .
    )
```