### PR TITLE
Add pagination to list APIs: Activity notifications, User keywords, B…

### DIFF
--- a/src/main/java/com/example/cherrydan/activity/controller/ActivityController.java
+++ b/src/main/java/com/example/cherrydan/activity/controller/ActivityController.java
@@ -7,6 +7,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,10 +28,11 @@ public class ActivityController {
         description = "사용자의 활동 알림 목록을 조회합니다. 캠페인 타입에 따라 알림 타입이 구분됩니다."
     )
     @GetMapping("/notifications")
-    public List<ActivityNotificationResponseDTO> getActivityNotifications(
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser
+    public Page<ActivityNotificationResponseDTO> getActivityNotifications(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
     ) {
-        return activityService.getActivityNotifications(currentUser.getId());
+        return activityService.getActivityNotifications(currentUser.getId(), pageable);
     }
     
     @Operation(

--- a/src/main/java/com/example/cherrydan/activity/service/ActivityService.java
+++ b/src/main/java/com/example/cherrydan/activity/service/ActivityService.java
@@ -1,14 +1,16 @@
 package com.example.cherrydan.activity.service;
 
 import com.example.cherrydan.activity.dto.ActivityNotificationResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ActivityService {
     
     /**
-     * 사용자의 활동 알림 목록 조회
+     * 사용자의 활동 알림 목록 조회 (페이지네이션)
      */
-    List<ActivityNotificationResponseDTO> getActivityNotifications(Long userId);
+    Page<ActivityNotificationResponseDTO> getActivityNotifications(Long userId, Pageable pageable);
     
     /**
      * 활동 알림 읽음 처리 (배열)

--- a/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
@@ -4,6 +4,9 @@ import com.example.cherrydan.campaign.dto.BookmarkResponseDTO;
 import com.example.cherrydan.campaign.service.BookmarkService;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -38,10 +41,11 @@ public class BookmarkController {
 
     @Operation(summary = "내 북마크 목록 조회", description = "내가 북마크(찜)한 캠페인 목록을 조회합니다.")
     @GetMapping("/bookmarks")
-    public List<BookmarkResponseDTO> getBookmarks(
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser
+    public Page<BookmarkResponseDTO> getBookmarks(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
     ) {
-        return bookmarkService.getBookmarks(currentUser.getId());
+        return bookmarkService.getBookmarks(currentUser.getId(), pageable);
     }
 
     @Operation(summary = "북마크 완전 삭제", description = "캠페인 북마크(찜) 정보를 완전히 삭제합니다.")

--- a/src/main/java/com/example/cherrydan/campaign/repository/BookmarkRepository.java
+++ b/src/main/java/com/example/cherrydan/campaign/repository/BookmarkRepository.java
@@ -3,6 +3,8 @@ package com.example.cherrydan.campaign.repository;
 import com.example.cherrydan.campaign.domain.Bookmark;
 import com.example.cherrydan.campaign.domain.Campaign;
 import com.example.cherrydan.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
@@ -10,5 +12,6 @@ import java.util.Optional;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByUserAndCampaign(User user, Campaign campaign);
     List<Bookmark> findAllByUserAndIsActiveTrue(User user);
+    Page<Bookmark> findAllByUserAndIsActiveTrue(User user, Pageable pageable);
     void deleteByUserAndCampaign(User user, Campaign campaign);
 } 

--- a/src/main/java/com/example/cherrydan/campaign/repository/CampaignStatusRepository.java
+++ b/src/main/java/com/example/cherrydan/campaign/repository/CampaignStatusRepository.java
@@ -4,6 +4,8 @@ import com.example.cherrydan.campaign.domain.CampaignStatus;
 import com.example.cherrydan.campaign.domain.Campaign;
 import com.example.cherrydan.user.domain.User;
 import com.example.cherrydan.campaign.domain.CampaignStatusType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -40,4 +42,10 @@ public interface CampaignStatusRepository extends JpaRepository<CampaignStatus, 
      */
     @Query("SELECT cs FROM CampaignStatus cs WHERE cs.user.id = :userId AND cs.isVisibleToUser = true AND cs.isActive = true")
     List<CampaignStatus> findVisibleActivityByUserId(@Param("userId") Long userId);
+    
+    /**
+     * 사용자별로 isVisibleToUser = true인 활동 알림만 조회 (페이지네이션)
+     */
+    @Query("SELECT cs FROM CampaignStatus cs WHERE cs.user.id = :userId AND cs.isVisibleToUser = true AND cs.isActive = true")
+    Page<CampaignStatus> findVisibleActivityByUserId(@Param("userId") Long userId, Pageable pageable);
 } 

--- a/src/main/java/com/example/cherrydan/campaign/service/BookmarkService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/BookmarkService.java
@@ -1,11 +1,13 @@
 package com.example.cherrydan.campaign.service;
 
 import com.example.cherrydan.campaign.dto.BookmarkResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface BookmarkService {
     void addBookmark(Long userId, Long campaignId);
     void cancelBookmark(Long userId, Long campaignId);
-    List<BookmarkResponseDTO> getBookmarks(Long userId);
+    Page<BookmarkResponseDTO> getBookmarks(Long userId, Pageable pageable);
     void deleteBookmark(Long userId, Long campaignId);
 } 

--- a/src/main/java/com/example/cherrydan/campaign/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/BookmarkServiceImpl.java
@@ -11,6 +11,8 @@ import com.example.cherrydan.common.exception.ErrorMessage;
 import com.example.cherrydan.common.exception.UserException;
 import com.example.cherrydan.common.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
@@ -61,12 +63,11 @@ public class BookmarkServiceImpl implements BookmarkService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<BookmarkResponseDTO> getBookmarks(Long userId) {
+    public Page<BookmarkResponseDTO> getBookmarks(Long userId, Pageable pageable) {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
-        return bookmarkRepository.findAllByUserAndIsActiveTrue(user).stream()
-                .map(BookmarkResponseDTO::fromEntity)
-                .collect(Collectors.toList());
+        return bookmarkRepository.findAllByUserAndIsActiveTrue(user, pageable)
+                .map(BookmarkResponseDTO::fromEntity);
     }
 
     @Override

--- a/src/main/java/com/example/cherrydan/sns/controller/SnsController.java
+++ b/src/main/java/com/example/cherrydan/sns/controller/SnsController.java
@@ -12,6 +12,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -52,11 +55,12 @@ public class SnsController {
 
     @Operation(summary = "사용자 SNS 연동 목록 조회")
     @GetMapping("/connections")
-    public ApiResponse<List<SnsConnectionResponse>> getConnections(
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ApiResponse<Page<SnsConnectionResponse>> getConnections(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
         User user = userService.getUserById(userDetails.getId());
         
-        List<SnsConnectionResponse> response = snsOAuthService.getUserSnsConnections(user);
+        Page<SnsConnectionResponse> response = snsOAuthService.getUserSnsConnections(user, pageable);
         return ApiResponse.success("SNS 연동 목록 조회 성공", response);
     }
 

--- a/src/main/java/com/example/cherrydan/sns/repository/SnsConnectionRepository.java
+++ b/src/main/java/com/example/cherrydan/sns/repository/SnsConnectionRepository.java
@@ -3,6 +3,8 @@ package com.example.cherrydan.sns.repository;
 import com.example.cherrydan.sns.domain.SnsConnection;
 import com.example.cherrydan.sns.domain.SnsPlatform;
 import com.example.cherrydan.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,6 +21,9 @@ public interface SnsConnectionRepository extends JpaRepository<SnsConnection, Lo
 
     @Query("SELECT sc FROM SnsConnection sc WHERE sc.user = :user AND sc.isActive = true AND sc.user.isActive = true")
     List<SnsConnection> findByUser(@Param("user") User user);
+
+    @Query("SELECT sc FROM SnsConnection sc WHERE sc.user = :user AND sc.isActive = true AND sc.user.isActive = true")
+    Page<SnsConnection> findAllByUserAndIsActiveTrue(@Param("user") User user, Pageable pageable);
 
     @Query("SELECT sc FROM SnsConnection sc WHERE sc.user = :user AND sc.platform = :platform AND sc.user.isActive = true")
     Optional<SnsConnection> findByUserAndPlatformIgnoreActive(@Param("user") User user, @Param("platform") SnsPlatform platform);

--- a/src/main/java/com/example/cherrydan/user/controller/UserController.java
+++ b/src/main/java/com/example/cherrydan/user/controller/UserController.java
@@ -14,6 +14,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -83,10 +86,12 @@ public class UserController {
 
     @Operation(summary = "내 키워드 목록 조회", security = { @SecurityRequirement(name = "bearerAuth") })
     @GetMapping("/me/keywords")
-    public ResponseEntity<ApiResponse<List<UserKeywordResponseDTO>>> getMyKeywords(@AuthenticationPrincipal UserDetailsImpl currentUser) {
+    public ResponseEntity<ApiResponse<Page<UserKeywordResponseDTO>>> getMyKeywords(
+            @AuthenticationPrincipal UserDetailsImpl currentUser,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
         if (currentUser == null) throw new AuthException(ErrorMessage.AUTH_UNAUTHORIZED);
-        List<UserKeywordResponseDTO> dtos = userKeywordService.getKeywords(currentUser.getId())
-            .stream().map(UserKeywordResponseDTO::fromKeyword).toList();
+        Page<UserKeywordResponseDTO> dtos = userKeywordService.getKeywords(currentUser.getId(), pageable)
+            .map(UserKeywordResponseDTO::fromKeyword);
         return ResponseEntity.ok(ApiResponse.success("키워드 목록 조회 성공", dtos));
     }
 

--- a/src/main/java/com/example/cherrydan/user/controller/UserKeywordController.java
+++ b/src/main/java/com/example/cherrydan/user/controller/UserKeywordController.java
@@ -10,8 +10,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,10 +32,11 @@ public class UserKeywordController {
         description = "사용자의 키워드 알림 히스토리를 조회합니다."
     )
     @GetMapping("/alerts")
-    public List<KeywordCampaignAlertResponseDTO> getUserKeywordAlerts(
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser
+    public Page<KeywordCampaignAlertResponseDTO> getUserKeywordAlerts(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
+            @PageableDefault(size = 20, sort = "alertDate") Pageable pageable
     ) {
-        return userKeywordService.getUserKeywordAlerts(currentUser.getId());
+        return userKeywordService.getUserKeywordAlerts(currentUser.getId(), pageable);
     }
     
 

--- a/src/main/java/com/example/cherrydan/user/repository/KeywordCampaignAlertRepository.java
+++ b/src/main/java/com/example/cherrydan/user/repository/KeywordCampaignAlertRepository.java
@@ -1,6 +1,8 @@
 package com.example.cherrydan.user.repository;
 
 import com.example.cherrydan.user.domain.KeywordCampaignAlert;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +16,12 @@ public interface KeywordCampaignAlertRepository extends JpaRepository<KeywordCam
      */
     @Query("SELECT kca FROM KeywordCampaignAlert kca WHERE kca.user.id = :userId AND kca.isVisibleToUser = true ORDER BY kca.alertDate DESC")
     List<KeywordCampaignAlert> findByUserIdAndIsVisibleToUserTrue(@Param("userId") Long userId);
+    
+    /**
+     * 사용자의 키워드 알림 목록 조회 (페이지네이션)
+     */
+    @Query("SELECT kca FROM KeywordCampaignAlert kca WHERE kca.user.id = :userId AND kca.isVisibleToUser = true ORDER BY kca.alertDate DESC")
+    Page<KeywordCampaignAlert> findByUserIdAndIsVisibleToUserTrue(@Param("userId") Long userId, Pageable pageable);
     
     /**
      * 알림 미발송된 키워드 알림들 조회

--- a/src/main/java/com/example/cherrydan/user/repository/UserKeywordRepository.java
+++ b/src/main/java/com/example/cherrydan/user/repository/UserKeywordRepository.java
@@ -1,6 +1,8 @@
 package com.example.cherrydan.user.repository;
 
 import com.example.cherrydan.user.domain.UserKeyword;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +13,9 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
     // 활성 사용자만 조회하는 메서드들
     @Query("SELECT uk FROM UserKeyword uk WHERE uk.user.id = :userId AND uk.user.isActive = true")
     List<UserKeyword> findByUserId(@Param("userId") Long userId);
+    
+    @Query("SELECT uk FROM UserKeyword uk WHERE uk.user.id = :userId AND uk.user.isActive = true")
+    Page<UserKeyword> findByUserId(@Param("userId") Long userId, Pageable pageable);
     
     @Query("SELECT uk FROM UserKeyword uk WHERE uk.user.id = :userId AND uk.keyword = :keyword AND uk.user.isActive = true")
     Optional<UserKeyword> findByUserIdAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);

--- a/src/main/java/com/example/cherrydan/user/service/UserKeywordService.java
+++ b/src/main/java/com/example/cherrydan/user/service/UserKeywordService.java
@@ -54,11 +54,11 @@ public class UserKeywordService {
     }
 
     @Transactional(readOnly = true)
-    public List<UserKeyword> getKeywords(Long userId) {
+    public Page<UserKeyword> getKeywords(Long userId, Pageable pageable) {
         // 활성 사용자인지 확인
         userRepository.findActiveById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
-        return userKeywordRepository.findByUserId(userId);
+        return userKeywordRepository.findByUserId(userId, pageable);
     }
 
     @Transactional
@@ -294,16 +294,13 @@ public class UserKeywordService {
         log.info("키워드 맞춤 알림 발송 완료: 총 {}명에게 발송", totalSent);
     }
 
-
     /**
-     * 사용자의 키워드 알림 목록 조회
+     * 사용자의 키워드 알림 목록 조회 (페이지네이션)
      */
     @Transactional(readOnly = true)
-    public List<KeywordCampaignAlertResponseDTO> getUserKeywordAlerts(Long userId) {
-        return keywordAlertRepository.findByUserIdAndIsVisibleToUserTrue(userId)
-                .stream()
-                .map(KeywordCampaignAlertResponseDTO::fromEntity)
-                .collect(Collectors.toList());
+    public Page<KeywordCampaignAlertResponseDTO> getUserKeywordAlerts(Long userId, Pageable pageable) {
+        return keywordAlertRepository.findByUserIdAndIsVisibleToUserTrue(userId, pageable)
+                .map(KeywordCampaignAlertResponseDTO::fromEntity);
     }
 
     private String getKeywordAlertTitle(int campaignCount) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,7 +10,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update # 프로덕션에서는 스키마를 자동으로 변경하지 않도록 validate 사용
+      ddl-auto: validate # 프로덕션에서는 스키마를 자동으로 변경하지 않도록 validate 사용
     show-sql: false
     properties:
       hibernate:
@@ -68,6 +68,10 @@ logging:
     com.example.cherrydan: INFO # 프로덕션에서는 INFO 레벨로 로깅
     org.hibernate.SQL: off
     org.springframework.web: INFO
+    # Broken pipe 에러 로그 줄이기
+    org.apache.catalina.connector: WARN
+    org.apache.coyote: WARN
+    org.springframework.web.context.request.async: WARN
   file:
     name: /var/log/cherrydan/application.log
 


### PR DESCRIPTION
### 변경사항
- Activity notifications API에 페이지네이션 적용
- User keywords API에 페이지네이션 적용  
- Bookmarks API에 페이지네이션 적용
- Keyword alerts API에 페이지네이션 적용
- SNS connections API에 페이지네이션 적용

### 개선사항
- 대량 데이터 처리 성능 최적화
- 일관된 API 응답 구조 (Page<T>)
- 기본 페이지 크기: 20개 (SNS는 10개)
- 정렬 기준: createdAt/alertDate

### API 변경
- `List<T>` → `Page<T>` 반환 타입 변경
- 페이지네이션 파라미터 지원: `?page=0&size=20&sort=createdAt,desc`