### PR TITLE
refactor: feat: 페이지네이션 응답 형식 통일 및 공통 PageResponse 도입

### DIFF
--- a/src/main/java/com/example/cherrydan/activity/controller/ActivityController.java
+++ b/src/main/java/com/example/cherrydan/activity/controller/ActivityController.java
@@ -2,6 +2,8 @@ package com.example.cherrydan.activity.controller;
 
 import com.example.cherrydan.activity.dto.ActivityNotificationResponseDTO;
 import com.example.cherrydan.activity.service.ActivityService;
+import com.example.cherrydan.common.response.ApiResponse;
+import com.example.cherrydan.common.response.PageResponse;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,14 +27,38 @@ public class ActivityController {
     
     @Operation(
         summary = "내 활동 알림 목록 조회",
-        description = "사용자의 활동 알림 목록을 조회합니다. 캠페인 타입에 따라 알림 타입이 구분됩니다."
+        description = """
+            사용자의 활동 알림 목록을 조회합니다. 캠페인 타입에 따라 알림 타입이 구분됩니다.
+            
+            **Request Body 예시:**
+            ```json
+            {
+              "page": 0,
+              "size": 10,
+              "sort": "activityNotifiedAt,desc"
+            }
+            ```
+            
+            **정렬 가능한 필드:**
+            - activityNotifiedAt: 활동 알림 생성 시각 (기본값, DESC)
+            
+            **정렬 형태 (둘 다 지원):**
+            - String 형태: "activityNotifiedAt,desc"
+            - Array 형태: ["activityNotifiedAt,desc"]
+            
+            **정렬 예시:**
+            - "activityNotifiedAt,desc" (최신순, 기본값)
+            - "activityNotifiedAt,asc" (오래된 순)
+            """
     )
     @GetMapping("/notifications")
-    public Page<ActivityNotificationResponseDTO> getActivityNotifications(
+    public ApiResponse<PageResponse<ActivityNotificationResponseDTO>> getActivityNotifications(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
-            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+            @PageableDefault(size = 20, sort = "activityNotifiedAt", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable
     ) {
-        return activityService.getActivityNotifications(currentUser.getId(), pageable);
+        Page<ActivityNotificationResponseDTO> notifications = activityService.getActivityNotifications(currentUser.getId(), pageable);
+        PageResponse<ActivityNotificationResponseDTO> response = PageResponse.from(notifications);
+        return ApiResponse.success("활동 알림 목록 조회 성공", response);
     }
     
     @Operation(
@@ -40,11 +66,12 @@ public class ActivityController {
         description = "활동 알림을 읽음 처리합니다. 1개 또는 여러개 모두 배열로 전달하세요."
     )
     @PutMapping("/notifications/read")
-    public void markNotificationsAsRead(
+    public ApiResponse<Void> markNotificationsAsRead(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestBody List<Long> campaignStatusIds
     ) {
         activityService.markNotificationsAsRead(currentUser.getId(), campaignStatusIds);
+        return ApiResponse.success("활동 알림 읽음 처리 완료", null);
     }
     
     @Operation(
@@ -69,8 +96,9 @@ public class ActivityController {
             """
     )
     @PostMapping("/notifications/send")
-    public void sendActivityNotifications() {
+    public ApiResponse<Void> sendActivityNotifications() {
         activityService.sendActivityNotifications();
+        return ApiResponse.success("활동 알림 발송 완료", null);
     }
 
     @Operation(
@@ -78,10 +106,11 @@ public class ActivityController {
         description = "활동 알림을 삭제합니다. 1개 또는 여러개 모두 배열로 전달하세요."
     )
     @DeleteMapping("/alerts")
-    public void deleteActivityAlerts(
+    public ApiResponse<Void> deleteActivityAlerts(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestBody List<Long> alertIds
     ) {
         activityService.deleteActivityAlerts(currentUser.getId(), alertIds);
+        return ApiResponse.success("활동 알림 삭제 완료", null);
     }
 } 

--- a/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
@@ -2,6 +2,8 @@ package com.example.cherrydan.campaign.controller;
 
 import com.example.cherrydan.campaign.dto.BookmarkResponseDTO;
 import com.example.cherrydan.campaign.service.BookmarkService;
+import com.example.cherrydan.common.response.ApiResponse;
+import com.example.cherrydan.common.response.PageResponse;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -39,13 +41,30 @@ public class BookmarkController {
         bookmarkService.cancelBookmark(currentUser.getId(), campaignId);
     }
 
-    @Operation(summary = "내 북마크 목록 조회", description = "내가 북마크(찜)한 캠페인 목록을 조회합니다.")
+    @Operation(
+        summary = "내 북마크 목록 조회", 
+        description = """
+            내가 북마크(찜)한 캠페인 목록을 조회합니다.
+            
+            **Request Body 예시:**
+            ```json
+            {
+              "page": 0,
+              "size": 20
+            }
+            ```
+            
+            **정렬**: 북마크 생성 시각 내림차순 (고정)
+            """
+    )
     @GetMapping("/bookmarks")
-    public Page<BookmarkResponseDTO> getBookmarks(
+    public ApiResponse<PageResponse<BookmarkResponseDTO>> getBookmarks(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
     ) {
-        return bookmarkService.getBookmarks(currentUser.getId(), pageable);
+        Page<BookmarkResponseDTO> bookmarks = bookmarkService.getBookmarks(currentUser.getId(), pageable);
+        PageResponse<BookmarkResponseDTO> response = PageResponse.from(bookmarks);
+        return ApiResponse.success("북마크 목록 조회 성공", response);
     }
 
     @Operation(summary = "북마크 완전 삭제", description = "캠페인 북마크(찜) 정보를 완전히 삭제합니다.")

--- a/src/main/java/com/example/cherrydan/common/response/PageResponse.java
+++ b/src/main/java/com/example/cherrydan/common/response/PageResponse.java
@@ -1,0 +1,50 @@
+package com.example.cherrydan.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "페이지네이션 응답")
+public class PageResponse<T> {
+    
+    @Schema(description = "데이터 목록")
+    private List<T> content;
+    
+    @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+    private int page;
+    
+    @Schema(description = "페이지 크기", example = "20")
+    private int size;
+    
+    @Schema(description = "전체 요소 수", example = "100")
+    private long totalElements;
+    
+    @Schema(description = "전체 페이지 수", example = "5")
+    private int totalPages;
+    
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    private boolean hasNext;
+    
+    @Schema(description = "이전 페이지 존재 여부", example = "false")
+    private boolean hasPrevious;
+    
+    /**
+     * Spring Data Page 객체를 PageResponse로 변환
+     */
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return PageResponse.<T>builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
+                .build();
+    }
+} 

--- a/src/main/java/com/example/cherrydan/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/cherrydan/notice/controller/NoticeController.java
@@ -1,14 +1,17 @@
 package com.example.cherrydan.notice.controller;
 
 import com.example.cherrydan.common.response.ApiResponse;
+import com.example.cherrydan.common.response.PageResponse;
 import com.example.cherrydan.notice.dto.NoticeResponseDTO;
 import com.example.cherrydan.notice.service.NoticeService;
 import com.example.cherrydan.notice.service.NoticeBannerService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -23,10 +26,39 @@ public class NoticeController {
     private final NoticeService noticeService;
     private final NoticeBannerService noticeBannerService;
 
-    @Operation(summary = "공지사항 목록 조회")
+    @Operation(
+        summary = "공지사항 목록 조회",
+        description = """
+            활성 상태인 공지사항 목록을 조회합니다.
+            
+            **Request Body 예시:**
+            ```json
+            {
+              "page": 0,
+              "size": 20,
+              "sort": "updatedAt,desc"
+            }
+            ```
+            
+            **정렬 가능한 필드:**
+            - updatedAt: 수정 시각 (기본값, DESC)
+            
+            **정렬 형태 (둘 다 지원):**
+            - String 형태: "updatedAt,desc"
+            - Array 형태: ["updatedAt,desc"]
+            
+            **정렬 예시:**
+            - "updatedAt,desc" (최신 수정순, 기본값)
+            - "updatedAt,asc" (오래된 수정순)
+            """
+    )
     @GetMapping
-    public ResponseEntity<ApiResponse<Page<NoticeResponseDTO>>> getNotices(Pageable pageable) {
-        Page<NoticeResponseDTO> response = noticeService.getActiveNotices(pageable);
+    public ResponseEntity<ApiResponse<PageResponse<NoticeResponseDTO>>> getNotices(
+            @Parameter(description = "페이지네이션 정보") 
+            @PageableDefault(size = 20, sort = "updatedAt") Pageable pageable
+    ) {
+        Page<NoticeResponseDTO> notices = noticeService.getActiveNotices(pageable);
+        PageResponse<NoticeResponseDTO> response = PageResponse.from(notices);
         return ResponseEntity.ok(ApiResponse.success("공지사항 목록 조회가 완료되었습니다.", response));
     }
 

--- a/src/main/java/com/example/cherrydan/user/service/UserKeywordService.java
+++ b/src/main/java/com/example/cherrydan/user/service/UserKeywordService.java
@@ -325,7 +325,7 @@ public class UserKeywordService {
      * 특정 키워드로 맞춤형 캠페인 목록 조회
      */
     @Transactional(readOnly = true)
-    public CampaignListResponseDTO getPersonalizedCampaignsByKeyword(Long userId, String keyword, Pageable pageable) {
+    public Page<CampaignResponseDTO> getPersonalizedCampaignsByKeyword(Long userId, String keyword, Pageable pageable) {
         // 해당 유저가 등록한 키워드인지 검증
         if (!userKeywordRepository.existsByUserIdAndKeyword(userId, keyword)) {
             throw new IllegalArgumentException("등록되지 않은 키워드입니다.");
@@ -344,19 +344,7 @@ public class UserKeywordService {
         };
 
         Page<Campaign> campaigns = campaignRepository.findAll(spec, pageable);
-        List<CampaignResponseDTO> content = campaigns.getContent().stream()
-                .map(CampaignResponseDTO::fromEntity)
-                .collect(Collectors.toList());
-
-        return CampaignListResponseDTO.builder()
-                .content(content)
-                .page(campaigns.getNumber())
-                .size(campaigns.getSize())
-                .totalElements(campaigns.getTotalElements())
-                .totalPages(campaigns.getTotalPages())
-                .hasNext(campaigns.hasNext())
-                .hasPrevious(campaigns.hasPrevious())
-                .build();
+        return campaigns.map(CampaignResponseDTO::fromEntity);
     }
 
     /**


### PR DESCRIPTION
feat: 페이지네이션 응답 형식 통일 및 공통 PageResponse 도입

- 모든 페이지네이션 API 응답을 PageResponse<T>로 통일
- Activity, Bookmark, Notice, MyPage, User, UserKeyword 컨트롤러 수정
- 개별 DTO (CampaignListResponseDTO 등) 대신 공통 PageResponse 사용
- Swagger 문서에 정렬 조건 및 Request Body 예시 추가
- String/Array 정렬 형태 모두 지원한다고 명시
- UserKeywordService에서 Page<T> 직접 반환으로 변환 로직 간소화
- PageResponse.from() 메서드 활용으로 코드 가독성 향상

Changes:
- 새로운 공통 PageResponse<T> DTO 추가
- 6개 컨트롤러의 페이지네이션 API 응답 형식 통일
- API 문서화 개선 (정렬 조건, 예시 추가)
- 불필요한 변환 로직 제거 및 코드 간소화

필요한 거 있으면 또 말씀해 주세용~!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All paginated API responses are now returned in a standardized format, providing consistent pagination details across endpoints.
  * Success messages are now included in responses for notification and alert actions, improving user feedback.

* **Documentation**
  * Enhanced API documentation with detailed descriptions, usage examples, and improved parameter explanations for better clarity and usability.

* **Refactor**
  * Unified and simplified pagination handling across multiple endpoints for a more consistent and predictable API experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->