### PR TITLE
Refactor: 캠페인 API 내 불필요한 DTO 제거 및 명칭 정리

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignController.java
@@ -31,8 +31,6 @@ public class CampaignController {
     public ResponseEntity<ApiResponse<PageListResponseDTO<CampaignResponseDTO>>> getCampaignsByType(
         @Parameter(description = "캠페인 타입 (all, product, region, reporter, etc)", example = "all")
         @RequestParam(required = false, defaultValue = "all") String type,
-        @Parameter(description = "지역명 (선택)")
-        @RequestParam(required = false) String region,
         @Parameter(description = "정렬 기준 (popular, latest, deadline, low_competition)", example = "popular")
         @RequestParam(required = false, defaultValue = "popular") String sort,
         @Parameter(description = "페이지 번호", example = "0")
@@ -48,7 +46,7 @@ public class CampaignController {
         } catch (IllegalArgumentException e) {
             campaignType = null;
         }
-        PageListResponseDTO<CampaignResponseDTO> result = campaignService.getCampaigns(campaignType, region, sort, pageable);
+        PageListResponseDTO<CampaignResponseDTO> result = campaignService.getCampaigns(campaignType, sort, pageable);
         return ResponseEntity.ok(ApiResponse.success("캠페인 목록 조회가 완료되었습니다.", result));
     }
 

--- a/src/main/java/com/example/cherrydan/campaign/dto/BookmarkResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/BookmarkResponseDTO.java
@@ -21,30 +21,30 @@ public class BookmarkResponseDTO {
     private String campaignTitle;
     private String campaignDetailUrl;
     private String campaignImageUrl;
-    private String snsPlatformImageUrl;
+    private String campaignPlatformImageUrl;
     private String benefit;
     private Integer applicantCount;
     private Integer recruitCount;
     private List<String> snsPlatforms;
     private String reviewerAnnouncementStatus;
-    private String campaignPlatform;
+    private String campaignSite;
 
     public static BookmarkResponseDTO fromEntity(Bookmark bookmark) {
         Campaign campaign = bookmark.getCampaign();
-        String snsPlatformImageUrl = CloudfrontUtil.getSnsPlatformImageUrl(campaign.getSourceSite());
+        String campaignPlatformImageUrl = CloudfrontUtil.getCampaignPlatformImageUrl(campaign.getSourceSite());
         return BookmarkResponseDTO.builder()
                 .id(bookmark.getId())
                 .campaignId(campaign.getId())
                 .campaignTitle(campaign.getTitle())
                 .campaignDetailUrl(campaign.getDetailUrl())
                 .campaignImageUrl(campaign.getImageUrl())
-                .snsPlatformImageUrl(snsPlatformImageUrl)
+                .campaignPlatformImageUrl(campaignPlatformImageUrl)
                 .benefit(campaign.getBenefit())
                 .applicantCount(campaign.getApplicantCount())
                 .recruitCount(campaign.getRecruitCount())
                 .snsPlatforms(getPlatforms(campaign))
                 .reviewerAnnouncementStatus(getReviewerAnnouncementStatus(campaign.getReviewerAnnouncement()))
-                .campaignPlatform(getCampaignPlatformLabel(campaign.getSourceSite()))
+                .campaignSite(getCampaignSiteLabel(campaign.getSourceSite()))
                 .build();
     }
 
@@ -74,7 +74,7 @@ public class BookmarkResponseDTO {
         }
     }
 
-    public static String getCampaignPlatformLabel(String code) {
+    public static String getCampaignSiteLabel(String code) {
         if (code == null) return null;
         try {
             return CampaignPlatformType.fromCode(code).getLabel();

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
@@ -23,6 +23,7 @@ public class CampaignResponseDTO {
     private String reviewerAnnouncementStatus;
     private Integer applicantCount;
     private Integer recruitCount;
+    @JsonProperty("campaignSite")
     private String sourceSite;
     private String imageUrl;
     @JsonIgnore private Boolean youtube;
@@ -33,15 +34,12 @@ public class CampaignResponseDTO {
     @JsonIgnore private Boolean clip;
     @JsonIgnore private Boolean tiktok;
     @JsonIgnore private Boolean etc;
-    private String snsPlatformImageUrl;
+    private String campaignPlatformImageUrl;
     private CampaignType campaignType;
-    private String address;
     private Float competitionRate;
-    private Integer localCategory;
-    private Integer productCategory;
 
-    @JsonProperty("platforms")
-    public List<String> getPlatforms() {
+    @JsonProperty("snsPlatforms")
+    public List<String> getSnsPlatforms() {
         List<String> platforms = new ArrayList<>();
         if (Boolean.TRUE.equals(youtube)) platforms.add(SnsPlatformType.YOUTUBE.getLabel());
         if (Boolean.TRUE.equals(shorts)) platforms.add("쇼츠");
@@ -78,7 +76,7 @@ public class CampaignResponseDTO {
     }
 
     public static CampaignResponseDTO fromEntity(Campaign campaign) {
-        String snsPlatformImageUrl = CloudfrontUtil.getSnsPlatformImageUrl(campaign.getSourceSite());
+        String campaignPlatformImageUrl = CloudfrontUtil.getCampaignPlatformImageUrl(campaign.getSourceSite());
         return CampaignResponseDTO.builder()
             .id(campaign.getId())
             .title(campaign.getTitle())
@@ -97,12 +95,9 @@ public class CampaignResponseDTO {
             .clip(campaign.getClip())
             .tiktok(campaign.getTiktok())
             .etc(campaign.getEtc())
-            .snsPlatformImageUrl(snsPlatformImageUrl)
+            .campaignPlatformImageUrl(campaignPlatformImageUrl)
             .campaignType(campaign.getCampaignType())
-            .address(campaign.getAddress())
             .competitionRate(campaign.getCompetitionRate())
-            .localCategory(campaign.getLocalCategory())
-            .productCategory(campaign.getProductCategory())
             .build();
     }
 } 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.example.cherrydan.common.util.CloudfrontUtil;
+import com.example.cherrydan.campaign.dto.BookmarkResponseDTO;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -24,11 +25,11 @@ public class CampaignStatusResponseDTO {
     private String benefit;
     private String detailUrl;
     private String imageUrl;
-    private String snsPlatformImageUrl;
+    private String campaignPlatformImageUrl;
     private int applicantCount;
     private int recruitCount;
     private List<String> snsPlatforms;
-    private String campaignPlatform;
+    private String campaignSite;
     @JsonIgnore private LocalDate reviewerAnnouncement;
     @JsonIgnore private LocalDate contentSubmissionEnd;
     @JsonIgnore private LocalDate resultAnnouncement;
@@ -81,7 +82,7 @@ public class CampaignStatusResponseDTO {
                 break;
         }
 
-        String snsPlatformImageUrl = CloudfrontUtil.getSnsPlatformImageUrl(status.getCampaign().getSourceSite());
+        String campaignPlatformImageUrl = CloudfrontUtil.getCampaignPlatformImageUrl(status.getCampaign().getSourceSite());
         return CampaignStatusResponseDTO.builder()
                 .id(status.getId())
                 .campaignId(status.getCampaign().getId())
@@ -90,13 +91,13 @@ public class CampaignStatusResponseDTO {
                 .title(status.getCampaign().getTitle())
                 .detailUrl(status.getCampaign().getDetailUrl())
                 .imageUrl(status.getCampaign().getImageUrl())
-                .snsPlatformImageUrl(snsPlatformImageUrl)
+                .campaignPlatformImageUrl(campaignPlatformImageUrl)
                 .reviewerAnnouncement(status.getCampaign().getReviewerAnnouncement())
                 .reviewerAnnouncementStatus(reviewerAnnouncementStatus)
                 .applicantCount(status.getCampaign().getApplicantCount())
                 .recruitCount(status.getCampaign().getRecruitCount())
-                .snsPlatforms(com.example.cherrydan.campaign.dto.BookmarkResponseDTO.getPlatforms(status.getCampaign()))
-                .campaignPlatform(com.example.cherrydan.campaign.dto.BookmarkResponseDTO.getCampaignPlatformLabel(status.getCampaign().getSourceSite()))
+                .snsPlatforms(BookmarkResponseDTO.getPlatforms(status.getCampaign()))
+                .campaignSite(BookmarkResponseDTO.getCampaignSiteLabel(status.getCampaign().getSourceSite()))
                 .benefit(status.getCampaign().getBenefit())
                 .contentSubmissionEnd(status.getCampaign().getContentSubmissionEnd())
                 .resultAnnouncement(status.getCampaign().getResultAnnouncement())

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignService.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Pageable;
 public interface CampaignService {
     PageListResponseDTO<CampaignResponseDTO> getCampaigns(
         CampaignType type,
-        String region,
         String sort,
         Pageable pageable
     );

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
@@ -23,7 +23,7 @@ public class CampaignServiceImpl implements CampaignService {
     private final CampaignRepository campaignRepository;
 
     @Override
-    public PageListResponseDTO<CampaignResponseDTO> getCampaigns(CampaignType type, String region, String sort, Pageable pageable) {
+    public PageListResponseDTO<CampaignResponseDTO> getCampaigns(CampaignType type, String sort, Pageable pageable) {
         Page<Campaign> campaigns;
         
         if (type != null) {

--- a/src/main/java/com/example/cherrydan/common/util/CloudfrontUtil.java
+++ b/src/main/java/com/example/cherrydan/common/util/CloudfrontUtil.java
@@ -1,7 +1,7 @@
 package com.example.cherrydan.common.util;
 
 public class CloudfrontUtil {
-    public static String getSnsPlatformImageUrl(String sourceSite) {
+    public static String getCampaignPlatformImageUrl(String sourceSite) {
         String cloudfrontUrl = System.getenv("CLOUDFRONT_URL");
         if (cloudfrontUrl != null && sourceSite != null && !sourceSite.isBlank()) {
             return (cloudfrontUrl.endsWith("/") ? cloudfrontUrl : cloudfrontUrl + "/") + sourceSite + ".png";


### PR DESCRIPTION
# Pull Request: Refactor: 캠페인 API 내 불필요한 DTO 제거 및 명칭 정리

## 변경 사항 요약
Response 응답 수정했습니다!

## 변경 이유
불필요한 DTO 제거 및 불명확한 네이밍 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * None.

* **Refactor**
  * Renamed several fields and methods related to campaign platform/site for improved clarity in campaign and bookmark responses.
  * Updated JSON property names for consistency (e.g., "platforms" to "snsPlatforms", "campaignSite").
  * Removed unused fields such as address and category information from campaign responses.
  * Removed the region parameter from campaign-related APIs and services, simplifying campaign retrieval.
  * Updated platform image URL utility method name for consistency.

* **Bug Fixes**
  * None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->