### PR TITLE
[Feature] #15 체험단 플랫폼 사이트 보여주는 API 추가

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignCategoryController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignCategoryController.java
@@ -18,7 +18,7 @@ import com.example.cherrydan.campaign.dto.CampaignResponseDTO;
 @RestController
 @RequestMapping("/api/campaigns/categories")
 @RequiredArgsConstructor
-@Tag(name = "Campaign Category API", description = "카테고리별 캠페인 검색 API")
+@Tag(name = "Campaign API", description = "캠페인(체험단) 관련 API")
 public class CampaignCategoryController {
 
     private final CampaignCategoryService campaignCategoryService;

--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignSiteController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignSiteController.java
@@ -3,6 +3,8 @@ package com.example.cherrydan.campaign.controller;
 import com.example.cherrydan.campaign.dto.CampaignSiteResponseDTO;
 import com.example.cherrydan.campaign.service.CampaignSiteService;
 import com.example.cherrydan.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,12 +12,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
+@Tag(name = "Campaign API", description = "캠페인(체험단) 관련 API")
 @RestController
 @RequestMapping("/api/campaign/site")
 @RequiredArgsConstructor
 public class CampaignSiteController {
     private final CampaignSiteService campaignSiteService;
 
+    @Operation(
+        summary = "캠페인 사이트 목록 조회",
+        description = "캠페인 사이트의 한글명과 CDN URL 목록을 우선순위대로 반환합니다."
+    )
     @GetMapping
     public ResponseEntity<ApiResponse<List<CampaignSiteResponseDTO>>> getAllSites() {
         List<CampaignSiteResponseDTO> sites = campaignSiteService.getAllSites();

--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignSiteController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignSiteController.java
@@ -1,0 +1,24 @@
+package com.example.cherrydan.campaign.controller;
+
+import com.example.cherrydan.campaign.dto.CampaignSiteResponseDTO;
+import com.example.cherrydan.campaign.service.CampaignSiteService;
+import com.example.cherrydan.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/campaign/site")
+@RequiredArgsConstructor
+public class CampaignSiteController {
+    private final CampaignSiteService campaignSiteService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CampaignSiteResponseDTO>>> getAllSites() {
+        List<CampaignSiteResponseDTO> sites = campaignSiteService.getAllSites();
+        return ResponseEntity.ok(ApiResponse.success("캠페인 사이트 목록 조회 성공", sites));
+    }
+} 

--- a/src/main/java/com/example/cherrydan/campaign/domain/CampaignSite.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/CampaignSite.java
@@ -1,0 +1,29 @@
+package com.example.cherrydan.campaign.domain;
+
+import com.example.cherrydan.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "campaign_site")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CampaignSite extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "site_name_kr", nullable = false, length = 100)
+    private String siteNameKr;
+
+    @Column(name = "site_name_en", nullable = false, length = 100, unique = true)
+    private String siteNameEn;
+
+    @Column(name = "priority", nullable = false)
+    private int priority;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+} 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignSiteResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignSiteResponseDTO.java
@@ -1,0 +1,15 @@
+package com.example.cherrydan.campaign.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CampaignSiteResponseDTO {
+    private String siteNameKr;
+    private String cdnUrl;
+} 

--- a/src/main/java/com/example/cherrydan/campaign/repository/CampaignSiteRepository.java
+++ b/src/main/java/com/example/cherrydan/campaign/repository/CampaignSiteRepository.java
@@ -1,0 +1,11 @@
+package com.example.cherrydan.campaign.repository;
+
+import com.example.cherrydan.campaign.domain.CampaignSite;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface CampaignSiteRepository extends JpaRepository<CampaignSite, Long> {
+    List<CampaignSite> findAllByIsActiveTrueOrderByPriorityAsc();
+} 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignSiteService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignSiteService.java
@@ -1,0 +1,8 @@
+package com.example.cherrydan.campaign.service;
+
+import com.example.cherrydan.campaign.dto.CampaignSiteResponseDTO;
+import java.util.List;
+
+public interface CampaignSiteService {
+    List<CampaignSiteResponseDTO> getAllSites();
+} 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignSiteServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignSiteServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.cherrydan.campaign.service;
+
+import com.example.cherrydan.campaign.domain.CampaignSite;
+import com.example.cherrydan.campaign.dto.CampaignSiteResponseDTO;
+import com.example.cherrydan.campaign.repository.CampaignSiteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CampaignSiteServiceImpl implements CampaignSiteService {
+    private final CampaignSiteRepository campaignSiteRepository;
+
+    @Value("${cdn.base-url}")
+    private String cdnBaseUrl;
+
+    @Override
+    public List<CampaignSiteResponseDTO> getAllSites() {
+        return campaignSiteRepository.findAllByIsActiveTrueOrderByPriorityAsc().stream()
+                .map(site -> CampaignSiteResponseDTO.builder()
+                        .siteNameKr(site.getSiteNameKr())
+                        .cdnUrl(cdnBaseUrl.endsWith("/") ? cdnBaseUrl + site.getSiteNameEn() + ".png" : cdnBaseUrl + "/" + site.getSiteNameEn() + ".png")
+                        .build())
+                .collect(Collectors.toList());
+    }
+} 

--- a/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/campaigns/types").permitAll()
                         .requestMatchers("/api/campaigns/sns-platforms").permitAll()
                         .requestMatchers("/api/campaigns/campaign-platforms").permitAll()
+                        .requestMatchers("/api/campaign/site").permitAll()
                         // 공지사항/홈 광고 배너 관련 경로
                         .requestMatchers("/api/notices/**").permitAll()
                         // 나머지는 인증 필요


### PR DESCRIPTION
# Pull Request: [Feature] #15 체험단 플랫폼 사이트 보여주는 API 추가

## 관련 이슈
#15 

## 변경 사항 요약
- 체험단 플랫폼 사이트 정보 내려주는 API 추가했습니다!

## 변경 이유
앱에서 정적으로 관리하는 것보다 동적으로 관리하는 것이 향후에 유연하게 대처 가능할 것 같아 추가했습니다!

## 참고 사항
- site만 관리하는 테이블 1개 추가했습니다!
