### PR TITLE
[Fix] 캠페인 검색, 캠페인 사이트 리스트 조회 API Oauth 인증 제외 반영

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignSiteController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignSiteController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Tag(name = "Campaign API", description = "캠페인(체험단) 관련 API")
 @RestController
-@RequestMapping("/api/campaign/site")
+@RequestMapping("/api/campaigns/site")
 @RequiredArgsConstructor
 public class CampaignSiteController {
     private final CampaignSiteService campaignSiteService;

--- a/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
@@ -50,10 +50,8 @@ public class SecurityConfig {
                         // OAuth2 관련 경로
                         .requestMatchers("/api/oauth2/**", "/api/login/oauth2/**").permitAll()
                         // 캠페인 관련 경로
-                        .requestMatchers("/api/campaigns/types").permitAll()
-                        .requestMatchers("/api/campaigns/sns-platforms").permitAll()
-                        .requestMatchers("/api/campaigns/campaign-platforms").permitAll()
-                        .requestMatchers("/api/campaign/site").permitAll()
+                        .requestMatchers("/api/campaigns/**").permitAll()
+                        .requestMatchers("/api/campaigns/site").permitAll()
                         // 공지사항/홈 광고 배너 관련 경로
                         .requestMatchers("/api/notices/**").permitAll()
                         // 나머지는 인증 필요


### PR DESCRIPTION
# Pull Request:
[Fix] 캠페인 검색, 캠페인 사이트 리스트 조회 API Oauth 인증 제외 반영

## 관련 이슈
#15  

## 변경 사항 요약
- 캠페인 검색, 사이트 리스트 조회 API JWT 인증 제외 추가했습니다!

