### PR TITLE
[Fix] JWT 인증 제외 리스트 중 공지사항/홈 광고 배너 관련 경로 수정

### DIFF
--- a/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/example/cherrydan/oauth/config/SecurityConfig.java
@@ -51,9 +51,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/oauth2/**", "/api/login/oauth2/**").permitAll()
                         // 캠페인 관련 경로
                         .requestMatchers("/api/campaigns/**").permitAll()
-                        .requestMatchers("/api/campaigns/site").permitAll()
                         // 공지사항/홈 광고 배너 관련 경로
-                        .requestMatchers("/api/notices/**").permitAll()
+                        .requestMatchers("/api/noticeboard/**").permitAll()
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
# Pull Request: [Fix] JWT 인증 제외 리스트 중 공지사항/홈 광고 배너 관련 경로 수정

## 변경 사항 요약
- JWT 인증 제외 리스트 중 공지사항/홈 광고 배너 관련 경로 수정했습니다.
- 기존 `notices`에서 `noticeboard`로 수정되어 변경했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated security settings, changing which API endpoints are accessible without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->