### PR TITLE
refactor: 도메인 책임 분리 및 알림/캠페인/키워드 서비스 개선

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignController.java
@@ -128,6 +128,12 @@ public class CampaignController {
         return ResponseEntity.ok(ApiResponse.success("캠페인 목록 조회가 완료되었습니다.", result));
     }
 
+    @GetMapping("/count")
+    public ResponseEntity<ApiResponse<Long>> getCampaignCountByKeyword(@RequestParam("keyword") String keyword) {
+        long count = campaignService.getCampaignCountByKeyword(keyword);
+        return ResponseEntity.ok(ApiResponse.success("캠페인 목록 조회가 완료되었습니다.", count));
+    }
+
     private Pageable createPageable(String sort, int page, int size) {
         switch (sort) {
             case "popular":

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignService.java
@@ -5,6 +5,7 @@ import com.example.cherrydan.campaign.domain.SnsPlatformType;
 import com.example.cherrydan.campaign.domain.CampaignPlatformType;
 import com.example.cherrydan.common.response.PageListResponseDTO;
 import com.example.cherrydan.campaign.dto.CampaignResponseDTO;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CampaignService {
@@ -25,4 +26,8 @@ public interface CampaignService {
     PageListResponseDTO<CampaignResponseDTO> getCampaignsByCampaignPlatform(CampaignPlatformType campaignPlatformType, String sort, Pageable pageable, Long userId);
 
     PageListResponseDTO<CampaignResponseDTO> searchByKeyword(String keyword, Pageable pageable, Long userId);
+
+    Page<CampaignResponseDTO> getPersonalizedCampaignsByKeyword(Long userId, String keyword, Pageable pageable);
+
+    long getCampaignCountByKeyword(String keyword);
 } 

--- a/src/main/java/com/example/cherrydan/common/aop/PerformanceAspect.java
+++ b/src/main/java/com/example/cherrydan/common/aop/PerformanceAspect.java
@@ -1,0 +1,28 @@
+package com.example.cherrydan.common.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Aspect
+@Component
+@Slf4j
+public class PerformanceAspect {
+    @Around("@annotation(performanceMonitor)")
+    public Object measureExecutionTime(ProceedingJoinPoint joinPoint, PerformanceMonitor performanceMonitor) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+        try {
+            return joinPoint.proceed();
+        } finally {
+            stopWatch.stop();
+            String methodName = joinPoint.getSignature().getName();
+            Object[] args = joinPoint.getArgs();
+            String keyword = args.length > 0 ? String.valueOf(args[0]) : "unknown";
+            log.info("메서드: {}, 키워드: '{}', 실행시간: {}ms", methodName, keyword, stopWatch.getTotalTimeMillis());
+        }
+    }
+} 

--- a/src/main/java/com/example/cherrydan/common/aop/PerformanceMonitor.java
+++ b/src/main/java/com/example/cherrydan/common/aop/PerformanceMonitor.java
@@ -1,0 +1,9 @@
+package com.example.cherrydan.common.aop;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PerformanceMonitor {
+    String value() default "";
+} 

--- a/src/main/java/com/example/cherrydan/fcm/service/NotificationService.java
+++ b/src/main/java/com/example/cherrydan/fcm/service/NotificationService.java
@@ -12,6 +12,7 @@ import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -53,10 +54,7 @@ public class NotificationService {
                     .collect(Collectors.toList());
             
             return sendMulticastNotification(tokenStrings, request, tokens);
-            
-        } catch (NotificationException e) {
-            throw e;
-        } catch (Exception e) {
+        }catch (Exception e) {
             log.error("사용자 {}에게 알림 전송 실패: {}", userId, e.getMessage());
             throw new NotificationException(ErrorMessage.NOTIFICATION_SEND_FAILED);
         }
@@ -65,6 +63,7 @@ public class NotificationService {
     /**
      * 여러 사용자에게 알림 전송
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = Exception.class)
     public NotificationResultDto sendNotificationToUsers(List<Long> userIds, NotificationRequest request) {
         try {
             List<UserFCMToken> tokens = tokenRepository.findActiveTokensByUserIds(userIds);

--- a/src/main/java/com/example/cherrydan/user/domain/UserLoginHistory.java
+++ b/src/main/java/com/example/cherrydan/user/domain/UserLoginHistory.java
@@ -1,0 +1,25 @@
+package com.example.cherrydan.user.domain;
+
+import com.example.cherrydan.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Table(name = "user_login_history")
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class UserLoginHistory extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "login_date")
+    private LocalDateTime loginDate;
+}

--- a/src/main/java/com/example/cherrydan/user/repository/UserLoginHistoryRepository.java
+++ b/src/main/java/com/example/cherrydan/user/repository/UserLoginHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.example.cherrydan.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.cherrydan.user.domain.UserLoginHistory;
+
+public interface UserLoginHistoryRepository extends JpaRepository<UserLoginHistory, Long> {
+}


### PR DESCRIPTION
refactor: 도메인 책임 분리 및 알림/캠페인/키워드 서비스 개선

---

## 주요 변경사항

- 캠페인 키워드 검색/카운트 로직 CampaignServiceImpl로 이동
- UserKeywordService는 검증만, 캠페인 쿼리는 CampaignService에 위임
- PerformanceMonitor AOP 및 어노테이션 추가
- 신규 엔티티(UserLoginHistory) 및 레포지토리 추가
- 기타 리팩터링 및 코드 정리

---

## 테스트 및 검증
- PerformanceMonitor 로그 정상 출력 확인

---

## 기타 참고사항

- 기존 컨트롤러/서비스에서 캠페인 관련 메서드 호출부가 변경되었으니 참고 바랍니다.
- 추가 개선/리팩터링 필요 시 코멘트 부탁드립니다.