### PR TITLE
Chore: 개발/운영 환경 분리 추가

### DIFF
--- a/src/main/java/com/example/cherrydan/oauth/config/OpenApiConfig.java
+++ b/src/main/java/com/example/cherrydan/oauth/config/OpenApiConfig.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.context.annotation.Profile;
 
+@Profile("dev")
 @Configuration
 @OpenAPIDefinition(
     info = @Info(

--- a/src/main/java/com/example/cherrydan/oauth/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/cherrydan/oauth/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.example.cherrydan.oauth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.context.annotation.Profile;
+
+@Profile("prod")
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+} 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,20 +1,24 @@
 spring:
   config:
     activate:
-      on-profile: prod
+      on-profile: dev
 
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    # url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/cherrydan-dev?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: update # 프로덕션에서는 스키마를 자동으로 변경하지 않도록 validate 사용
-    show-sql: false
+    show-sql: true
     properties:
       hibernate:
-        format_sql: false
+        format_sql: true
+        use_sql_comments: true
+        highlight_sql: true
+    
   security:
     oauth2:
       client:
@@ -54,10 +58,8 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token:
-    validity-in-minutes: 60
-  refresh-token:
-    validity-in-days: 14
+  expiration: 3600000
+  refresh-token-expiration: 604800000
 
 server:
   port: ${SERVER_PORT:8080}
@@ -74,6 +76,7 @@ logging:
     org.apache.catalina.connector: WARN
     org.apache.coyote: WARN
     org.springframework.web.context.request.async: WARN
+    org.hibernate.orm.jdbc.bind: TRACE 
   file:
     name: /var/log/cherrydan/application.log
 
@@ -119,9 +122,3 @@ fcm:
 
 cdn:
   base-url: ${CLOUDFRONT_URL:https://cdn.cherrydan.com/}
-
-springdoc:
-  api-docs:
-    enabled: false
-  swagger-ui:
-    enabled: false

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,14 +4,13 @@ spring:
       on-profile: dev
 
   datasource:
-    # url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/cherrydan-dev?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update # 프로덕션에서는 스키마를 자동으로 변경하지 않도록 validate 사용
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -58,8 +57,10 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  expiration: 3600000
-  refresh-token-expiration: 604800000
+  access-token:
+    validity-in-minutes: 60
+  refresh-token:
+    validity-in-days: 14
 
 server:
   port: ${SERVER_PORT:8080}
@@ -69,7 +70,7 @@ server:
 
 logging:
   level:
-    com.example.cherrydan: INFO # 프로덕션에서는 INFO 레벨로 로깅
+    com.example.cherrydan: INFO
     org.hibernate.SQL: off
     org.springframework.web: INFO
     # Broken pipe 에러 로그 줄이기
@@ -98,21 +99,21 @@ sns:
       instagram:
         client-id: ${INSTAGRAM_CLIENT_ID}
         client-secret: ${INSTAGRAM_CLIENT_SECRET}
-        redirect-uri: ${INSTAGRAM_REDIRECT_URI} # 프로덕션용 리디렉션 URI
+        redirect-uri: ${INSTAGRAM_REDIRECT_URI}
         auth-url: https://api.instagram.com/oauth/authorize
         token-url: https://api.instagram.com/oauth/access_token
         scope: user_profile,user_media
       youtube:
         client-id: ${YOUTUBE_CLIENT_ID}
         client-secret: ${YOUTUBE_CLIENT_SECRET}
-        redirect-uri: ${YOUTUBE_REDIRECT_URI} # 프로덕션용 리디렉션 URI
+        redirect-uri: ${YOUTUBE_REDIRECT_URI}
         auth-url: https://accounts.google.com/o/oauth2/v2/auth
         token-url: https://oauth2.googleapis.com/token
         scope: https://www.googleapis.com/auth/youtube.readonly
       tiktok:
         client-id: ${TIKTOK_CLIENT_ID}
         client-secret: ${TIKTOK_CLIENT_SECRET}
-        redirect-uri: ${TIKTOK_REDIRECT_URI} # 프로덕션용 리디렉션 URI
+        redirect-uri: ${TIKTOK_REDIRECT_URI}
         auth-url: https://www.tiktok.com/v2/auth/authorize
         token-url: https://open.tiktokapis.com/v2/oauth/token
         scope: user.info.basic


### PR DESCRIPTION
# Pull Request: Chore: 개발/운영 환경 분리 추가

## 변경 사항 요약
- dev, prod 환경 분리했습니다!
- swagger는 dev에서만 보이도록 세팅했슴돠

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration for the "dev" profile, including database, OAuth2, JWT, logging, and SNS settings.
  * Introduced a dedicated configuration class for providing a RestTemplate bean when running in the "prod" profile.

* **Chores**
  * Restricted API documentation configuration to only be active in the "dev" profile.
  * Disabled API documentation endpoints in the production profile for enhanced security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->