### PR TITLE
[Fix] Title 검색 시 중복되는 제목 제거되도록 기능 수정

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/repository/CampaignRepository.java
+++ b/src/main/java/com/example/cherrydan/campaign/repository/CampaignRepository.java
@@ -37,6 +37,6 @@ public interface CampaignRepository extends JpaRepository<Campaign, Long>, JpaSp
     @Query("SELECT c FROM Campaign c WHERE c.isActive = true")
     Page<Campaign> findActiveCampaigns(Pageable pageable);
 
-    @Query(value = "SELECT * FROM campaigns WHERE MATCH(title) AGAINST(:keyword IN BOOLEAN MODE) LIMIT 20", nativeQuery = true)
+    @Query(value = "SELECT * FROM campaigns WHERE MATCH(title) AGAINST(:keyword IN BOOLEAN MODE) and is_active = 1 GROUP BY title ORDER BY competition_rate LIMIT 20", nativeQuery = true)
     List<Campaign> searchByTitleFullText(@Param("keyword") String keyword);
 } 


### PR DESCRIPTION
# Pull Request: [Fix] Title 검색 시 중복되는 제목 제거되도록 기능 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results for campaigns now only include active campaigns, remove duplicates by title, and are sorted by competition rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->