### PR TITLE
Refactor: 엑세스 토큰 임시로 1분으로 변경

### DIFF
--- a/src/main/java/com/example/cherrydan/oauth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/cherrydan/oauth/security/jwt/JwtTokenProvider.java
@@ -24,7 +24,7 @@ public class JwtTokenProvider {
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secret,
-            @Value("${jwt.access-token.validity-in-minutes:60}") long accessTokenValidityInMinutes,
+            @Value("${jwt.access-token.validity-in-minutes:1}") long accessTokenValidityInMinutes,
             @Value("${jwt.refresh-token.validity-in-days:14}") long refreshTokenValidityInDays) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessTokenValidityInMinutes = accessTokenValidityInMinutes;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -58,7 +58,7 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   access-token:
-    validity-in-minutes: 60
+    validity-in-minutes: 1
   refresh-token:
     validity-in-days: 14
 


### PR DESCRIPTION
# Pull Request: Refactor: 엑세스 토큰 임시로 1분으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default access token expiration time from 60 minutes to 1 minute.
  * Adjusted development environment settings to reflect the new 1-minute access token validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->