### PR TITLE
[Refector] 캠페인 관련 API 카운팅 병목 현상 확인 및 수정

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignCategoryServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignCategoryServiceImpl.java
@@ -44,7 +44,7 @@ public class CampaignCategoryServiceImpl implements CampaignCategoryService {
     public PageListResponseDTO<CampaignResponseDTO> searchByCategory(String title, List<String> regionGroup, List<String> subRegion, List<String> local, List<String> product, String reporter, List<String> snsPlatform, List<String> campaignPlatform, String applyStart, String applyEnd, Pageable pageable, Long userId) {
         Specification<Campaign> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            predicates.add(cb.isTrue(root.get("isActive")));
+            predicates.add(cb.equal(root.get("isActive"), true));
 
             // 제목 조건 처리
             if (title != null && !title.trim().isEmpty()) {

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
@@ -58,7 +58,7 @@ public class CampaignServiceImpl implements CampaignService {
     ) {
         Specification<Campaign> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            predicates.add(cb.isTrue(root.get("isActive")));
+            predicates.add(cb.equal(root.get("isActive"), true));
 
             if (snsPlatform != null && !snsPlatform.isEmpty() && !snsPlatform.contains("all")) {
                 List<Predicate> snsPlatformPredicates = new ArrayList<>();
@@ -100,7 +100,7 @@ public class CampaignServiceImpl implements CampaignService {
     ) {
         Specification<Campaign> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            predicates.add(cb.isTrue(root.get("isActive")));
+            predicates.add(cb.equal(root.get("isActive"), true));
             if (platform != null && !platform.isEmpty() && !platform.contains("all")) {
                 List<Predicate> platformPredicates = new ArrayList<>();
                 for (String platformItem : platform) {
@@ -128,7 +128,7 @@ public class CampaignServiceImpl implements CampaignService {
         } else {
             Specification<Campaign> spec = (root, query, cb) -> {
                 List<Predicate> predicates = new ArrayList<>();
-                predicates.add(cb.isTrue(root.get("isActive")));
+                predicates.add(cb.equal(root.get("isActive"), true));
                 predicates.add(cb.or(
                     cb.equal(root.get("campaignType"), CampaignType.REGION),
                     cb.equal(root.get("campaignType"), CampaignType.PRODUCT)
@@ -147,7 +147,7 @@ public class CampaignServiceImpl implements CampaignService {
     public Page<CampaignResponseDTO> getPersonalizedCampaignsByKeyword(Long userId, String keyword, Pageable pageable) {
         Specification<Campaign> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            predicates.add(cb.isTrue(root.get("isActive")));
+            predicates.add(cb.equal(root.get("isActive"), true));
             String likeKeyword = "%" + keyword.trim() + "%";
             predicates.add(cb.or(
                 cb.like(root.get("title"), likeKeyword),
@@ -170,7 +170,7 @@ public class CampaignServiceImpl implements CampaignService {
         String trimmedKeyword = keyword.trim();
         Specification<Campaign> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            predicates.add(cb.isTrue(root.get("isActive")));
+            predicates.add(cb.equal(root.get("isActive"), true));
             String likeKeyword = "%" + trimmedKeyword + "%";
             predicates.add(cb.or(
                     cb.like(root.get("title"), likeKeyword),
@@ -193,7 +193,7 @@ public class CampaignServiceImpl implements CampaignService {
     ) {
         Specification<Campaign> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            predicates.add(cb.isTrue(root.get("isActive")));
+            predicates.add(cb.equal(root.get("isActive"), true));
             predicates.add(cb.equal(root.get("campaignType"), CampaignType.REGION));
             
             if (regionGroup != null && !regionGroup.isEmpty() && !regionGroup.contains("all")) {
@@ -262,7 +262,7 @@ public class CampaignServiceImpl implements CampaignService {
     ) {
         Specification<Campaign> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            predicates.add(cb.isTrue(root.get("isActive")));
+            predicates.add(cb.equal(root.get("isActive"), true));
             predicates.add(cb.equal(root.get("campaignType"), CampaignType.PRODUCT));
 
             if (productCategory != null && !productCategory.isEmpty()) {


### PR DESCRIPTION
# Pull Request: [Refector] 캠페인 관련 API 카운팅 병목 현상 확인 및 수정

## 변경 사항 요약
- 캠페인 API 쿼리에서 기존 `cb.isTrue(...)` 대신 `cb.equal(..., true)` 사용

## 변경 이유
- 지역 캠페인 로딩이 `200~2000ms` 정도로 오래 걸려서 확인

## 변경 내용
- As-Is: `cb.isTrue(...)` 해당 쿼리의 Explain 결과 `(NULL < is_active < 0) OR (0 < is_active)`로 탐색하고 있는 것을 확인. Index 자체는 사용되었지만, 효율이 떨어지는 Scan + Filter 구조로 개선 필요 인지
- To-Be: `cb.equal(..., true)`로 변경하여 `Covering Index` 테이블 접근 없이 인덱스만으로 데이터를 충족할 수 있게 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of filtering for active campaigns across various campaign search and filtering features. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->