### PR TITLE
Fix: 캠페인 관련 API Validation 추가 및 DTO 수정

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
@@ -4,6 +4,7 @@ import com.example.cherrydan.campaign.dto.BookmarkResponseDTO;
 import com.example.cherrydan.campaign.service.BookmarkService;
 import com.example.cherrydan.common.response.ApiResponse;
 import com.example.cherrydan.common.response.PageListResponseDTO;
+import com.example.cherrydan.common.response.EmptyResponse;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -32,20 +33,22 @@ public class BookmarkController {
 
     @Operation(summary = "북마크 추가", description = "캠페인에 북마크(찜)를 추가합니다.")
     @PostMapping("/{campaignId}/bookmark")
-    public void addBookmark(
+    public ResponseEntity<ApiResponse<EmptyResponse>> addBookmark(
             @Parameter(description = "캠페인 ID", required = true) @PathVariable Long campaignId,
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
         bookmarkService.addBookmark(currentUser.getId(), campaignId);
+        return ResponseEntity.ok(ApiResponse.success("북마크 추가 성공"));
     }
 
     @Operation(summary = "북마크 취소", description = "캠페인 북마크(찜)를 취소합니다. (is_active=0)")
     @PatchMapping("/{campaignId}/bookmark")
-    public void cancelBookmark(
+    public ResponseEntity<ApiResponse<EmptyResponse>> cancelBookmark(
             @Parameter(description = "캠페인 ID", required = true) @PathVariable Long campaignId,
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
         bookmarkService.cancelBookmark(currentUser.getId(), campaignId);
+        return ResponseEntity.ok(ApiResponse.success("북마크 취소 성공"));
     }
 
     @Operation(
@@ -73,10 +76,11 @@ public class BookmarkController {
 
     @Operation(summary = "북마크 완전 삭제", description = "캠페인 북마크(찜) 정보를 완전히 삭제합니다.")
     @DeleteMapping("/{campaignId}/bookmark")
-    public void deleteBookmark(
+    public ResponseEntity<ApiResponse<EmptyResponse>> deleteBookmark(
             @Parameter(description = "캠페인 ID", required = true) @PathVariable Long campaignId,
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
         bookmarkService.deleteBookmark(currentUser.getId(), campaignId);
+        return ResponseEntity.ok(ApiResponse.success("북마크 삭제 성공"));
     }
 } 

--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 @Tag(name = "CampaignStatus", description = "내 체험단 상태 관리 및 팝업 API")
 @RestController
@@ -36,7 +38,7 @@ public class CampaignStatusController {
     @Operation(summary = "내 체험단 상태 생성/변경", description = "기존 데이터 있으면 is_active or status 변경, 없으면 생성")
     @PostMapping
     public ResponseEntity<ApiResponse<CampaignStatusResponseDTO>> createOrRecoverStatus(
-        @RequestBody CampaignStatusRequestDTO requestDTO,
+        @Valid @RequestBody CampaignStatusRequestDTO requestDTO,
         @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
         requestDTO.setUserId(currentUser.getId());
@@ -47,7 +49,7 @@ public class CampaignStatusController {
     @Operation(summary = "내 체험단 상태 변경", description = "is_active or status 변경")
     @PatchMapping
     public ResponseEntity<ApiResponse<CampaignStatusResponseDTO>> updateStatus(
-        @RequestBody CampaignStatusRequestDTO requestDTO,
+        @Valid @RequestBody CampaignStatusRequestDTO requestDTO,
         @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
         requestDTO.setUserId(currentUser.getId());
@@ -58,7 +60,7 @@ public class CampaignStatusController {
     @Operation(summary = "내 체험단 상태 삭제", description = "campaignId만 받아서 삭제")
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> deleteStatus(
-        @RequestBody DeleteRequest request,
+        @Valid @RequestBody DeleteRequest request,
         @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
         campaignStatusService.deleteStatus(request.getCampaignId(), currentUser.getId());
@@ -75,6 +77,7 @@ public class CampaignStatusController {
     }
 
     public static class DeleteRequest {
+        @NotNull(message = "캠페인 ID는 필수입니다.")
         private Long campaignId;
         public Long getCampaignId() { return campaignId; }
         public void setCampaignId(Long campaignId) { this.campaignId = campaignId; }

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
@@ -12,6 +12,7 @@ import com.example.cherrydan.campaign.domain.CampaignType;
 import com.example.cherrydan.campaign.domain.SnsPlatformType;
 import com.example.cherrydan.campaign.domain.Campaign;
 import com.example.cherrydan.common.util.CloudfrontUtil;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @Builder
@@ -23,6 +24,9 @@ public class CampaignResponseDTO {
     private String reviewerAnnouncementStatus;
     private Integer applicantCount;
     private Integer recruitCount;
+
+    @Deprecated
+    @Schema(description = "플랫폼 이름(deprecated(v1.0.2까지))", deprecated = true)
     @JsonProperty("campaignSite")
     private String sourceSite;
     private String imageUrl;
@@ -35,7 +39,14 @@ public class CampaignResponseDTO {
     @JsonIgnore private Boolean tiktok;
     @JsonIgnore private Boolean etc;
     private Boolean isBookmarked;
+
+    @Deprecated
+    @Schema(description = "기존 플랫폼 이미지 URL(deprecated(v1.0.2까지))", deprecated = true)
     private String campaignPlatformImageUrl;
+    
+    private String campaignSiteUrl;
+    private String campaignSiteKr;
+    private String campaignSiteEn;
     private CampaignType campaignType;
     private Float competitionRate;
 
@@ -78,6 +89,8 @@ public class CampaignResponseDTO {
 
     public static CampaignResponseDTO fromEntityWithBookmark(Campaign campaign, boolean isBookmarked) {
         String campaignPlatformImageUrl = CloudfrontUtil.getCampaignPlatformImageUrl(campaign.getSourceSite());
+        String campaignSiteUrl = CloudfrontUtil.getCampaignPlatformImageUrl(campaign.getSourceSite());
+        CampaignPlatformType platformType = CampaignPlatformType.fromCode(campaign.getSourceSite());
         return CampaignResponseDTO.builder()
             .id(campaign.getId())
             .title(campaign.getTitle())
@@ -97,9 +110,12 @@ public class CampaignResponseDTO {
             .tiktok(campaign.getTiktok())
             .etc(campaign.getEtc())
             .campaignPlatformImageUrl(campaignPlatformImageUrl)
+            .campaignSiteUrl(campaignSiteUrl)
             .campaignType(campaign.getCampaignType())
             .competitionRate(campaign.getCompetitionRate())
             .isBookmarked(isBookmarked)
+            .campaignSiteKr(platformType.getLabel())
+            .campaignSiteEn(platformType.getCode())
             .build();
     }
 } 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignSiteResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignSiteResponseDTO.java
@@ -4,13 +4,29 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import com.example.cherrydan.campaign.domain.CampaignSite;
+import com.example.cherrydan.common.util.CloudfrontUtil;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class CampaignSiteResponseDTO {
+
+    @Deprecated
+    @Schema(description = "기존 플랫폼 한글명(deprecated(v1.0.2까지))", deprecated = true)
     private String siteNameKr;
+
+    @Deprecated
+    @Schema(description = "기존 플랫폼 영문명(deprecated(v1.0.2까지))", deprecated = true)
     private String siteNameEn;
+
+    @Deprecated
+    @Schema(description = "기존 플랫폼 CDN URL(deprecated(v1.0.2까지))", deprecated = true)
     private String cdnUrl;
+
+    private String campaignSiteUrl;
+    private String campaignSiteKr;
+    private String campaignSiteEn;
 } 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
@@ -5,13 +5,16 @@ import lombok.Getter;
 import lombok.Setter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 @Setter
 public class CampaignStatusRequestDTO {
+    @NotNull(message = "캠페인 ID는 필수입니다.")
     private Long campaignId;
     @JsonIgnore
     private Long userId;
+    @NotNull(message = "상태는 필수입니다.")
     @Schema(description = "캠페인 상태 타입 (APPLY: 신청, SELECTED: 선정, REGISTERED: 등록, ENDED: 종료)", example = "APPLY", allowableValues = {"APPLY", "SELECTED", "REGISTERED", "ENDED"})
     private CampaignStatusType status;
     private Boolean isActive;

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignSiteServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignSiteServiceImpl.java
@@ -25,6 +25,11 @@ public class CampaignSiteServiceImpl implements CampaignSiteService {
             .map(site -> {
                 String cdnUrl = CloudfrontUtil.getCampaignPlatformImageUrl(site.getSiteNameEn());
                 return CampaignSiteResponseDTO.builder()
+                        .campaignSiteKr(site.getSiteNameKr())
+                        .campaignSiteEn(site.getSiteNameEn())
+                        .campaignSiteUrl(cdnUrl)
+
+                        // deprecated(v1.0.2까지)
                         .siteNameKr(site.getSiteNameKr())
                         .siteNameEn(site.getSiteNameEn())
                         .cdnUrl(cdnUrl)

--- a/src/main/java/com/example/cherrydan/common/response/ApiResponse.java
+++ b/src/main/java/com/example/cherrydan/common/response/ApiResponse.java
@@ -28,6 +28,13 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> success() {
         return new ApiResponse<>(200, "API 요청이 성공했습니다.", null);
     }
+
+    /**
+     * 성공 응답 - 데이터 없고 메시지만 있음
+     */
+    public static ApiResponse<EmptyResponse> success(String message) {
+        return new ApiResponse<>(200, message, new EmptyResponse());
+    }
     
     /**
      * 성공 응답 - 커스텀 메시지

--- a/src/main/java/com/example/cherrydan/common/response/EmptyResponse.java
+++ b/src/main/java/com/example/cherrydan/common/response/EmptyResponse.java
@@ -1,0 +1,14 @@
+package com.example.cherrydan.common.response;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class EmptyResponse {
+    @JsonValue
+    public Map<String, Object> toJson() {
+        return new HashMap<>();
+    }
+} 

--- a/src/main/java/com/example/cherrydan/user/controller/UserController.java
+++ b/src/main/java/com/example/cherrydan/user/controller/UserController.java
@@ -1,16 +1,17 @@
 package com.example.cherrydan.user.controller;
 
+import com.example.cherrydan.common.response.ApiResponse;
+import com.example.cherrydan.common.response.EmptyResponse;
+import com.example.cherrydan.common.response.PageListResponseDTO;
 import com.example.cherrydan.common.exception.AuthException;
 import com.example.cherrydan.common.exception.ErrorMessage;
-import com.example.cherrydan.common.response.ApiResponse;
-import com.example.cherrydan.common.response.PageListResponseDTO;
-import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import com.example.cherrydan.user.domain.User;
 import com.example.cherrydan.user.dto.UserDto;
-import com.example.cherrydan.user.dto.UserUpdateRequestDTO;
 import com.example.cherrydan.user.dto.UserKeywordResponseDTO;
-import com.example.cherrydan.user.service.UserService;
+import com.example.cherrydan.user.dto.UserUpdateRequestDTO;
 import com.example.cherrydan.user.service.UserKeywordService;
+import com.example.cherrydan.user.service.UserService;
+import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -23,14 +24,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
 @Tag(name = "User", description = "사용자 정보 관련 API")
 public class UserController {
-
     private final UserService userService;
     private final UserKeywordService userKeywordService;
 
@@ -42,12 +40,9 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserDto>> getCurrentUser(
             @AuthenticationPrincipal UserDetailsImpl currentUser) {
-        
         if (currentUser == null) {
             throw new AuthException(ErrorMessage.AUTH_UNAUTHORIZED);
         }
-
-        // 서비스를 통해 사용자 정보 조회
         User user = userService.getUserById(currentUser.getId());
         UserDto userDto = new UserDto(user);
         
@@ -77,7 +72,7 @@ public class UserController {
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse<String>> deleteCurrentUser(
+    public ResponseEntity<ApiResponse<EmptyResponse>> deleteCurrentUser(
             @AuthenticationPrincipal UserDetailsImpl currentUser) {
         if (currentUser == null) {
             throw new AuthException(ErrorMessage.AUTH_UNAUTHORIZED);
@@ -115,18 +110,18 @@ public class UserController {
 
     @Operation(summary = "내 키워드 등록", security = { @SecurityRequirement(name = "bearerAuth") })
     @PostMapping("/me/keywords")
-    public ResponseEntity<ApiResponse<Void>> addMyKeyword(@AuthenticationPrincipal UserDetailsImpl currentUser, @RequestParam("keyword") String keyword) {
+    public ResponseEntity<ApiResponse<EmptyResponse>> addMyKeyword(@AuthenticationPrincipal UserDetailsImpl currentUser, @RequestParam("keyword") String keyword) {
         if (currentUser == null) throw new AuthException(ErrorMessage.AUTH_UNAUTHORIZED);
         userKeywordService.addKeyword(currentUser.getId(), keyword);
-        return ResponseEntity.ok(ApiResponse.success("키워드 등록 성공", null));
+        return ResponseEntity.ok(ApiResponse.success("키워드 등록 성공"));
     }
 
     @Operation(summary = "내 키워드 삭제", security = { @SecurityRequirement(name = "bearerAuth") })
     @DeleteMapping("/me/keywords/{keywordId}")
-    public ResponseEntity<ApiResponse<Void>> deleteMyKeyword(@AuthenticationPrincipal UserDetailsImpl currentUser, @PathVariable Long keywordId) {
+    public ResponseEntity<ApiResponse<EmptyResponse>> deleteMyKeyword(@AuthenticationPrincipal UserDetailsImpl currentUser, @PathVariable Long keywordId) {
         if (currentUser == null) throw new AuthException(ErrorMessage.AUTH_UNAUTHORIZED);
         userKeywordService.removeKeywordById(currentUser.getId(), keywordId);
-        return ResponseEntity.ok(ApiResponse.success("키워드 삭제 성공", null));
+        return ResponseEntity.ok(ApiResponse.success("키워드 삭제 성공"));
     }
 
     @Operation(
@@ -135,7 +130,7 @@ public class UserController {
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @PostMapping("/admin/restore/{userId}")
-    public ResponseEntity<ApiResponse<String>> restoreUser(
+    public ResponseEntity<ApiResponse<EmptyResponse>> restoreUser(
             @AuthenticationPrincipal UserDetailsImpl currentUser,
             @PathVariable("userId") Long userId) {
         if (currentUser == null) {


### PR DESCRIPTION
# Pull Request: Fix: 캠페인 관련 API Validation 추가 및 DTO 수정

## 변경 사항 요약
- 내 체험단 API Bean Validation 추가
- 캠페인, 유저 생성, 수정, 삭제 시 응답 DTO 일관되도록 수정
- 체험단 플랫폼 관련 DTO 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new fields to campaign-related responses, providing enhanced platform information.
  * Introduced an empty response object for standardized API responses without data.
  * Added custom success messages to certain API responses.

* **Improvements**
  * Deprecated outdated fields in campaign response objects for clearer API usage.
  * Enhanced input validation for campaign status operations, ensuring required fields are present.
  * Standardized API responses for user and bookmark actions to use empty response objects.

* **Bug Fixes**
  * Improved validation messages and error handling for required request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->