### PR TITLE
refactor: 전일 기준 키워드 캠페인 검색 로직을 추가했습니다

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/repository/CampaignRepository.java
+++ b/src/main/java/com/example/cherrydan/campaign/repository/CampaignRepository.java
@@ -41,34 +41,28 @@ public interface CampaignRepository extends JpaRepository<Campaign, Long>, JpaSp
     @Query(value = "SELECT * FROM campaigns WHERE MATCH(title) AGAINST(:keyword IN BOOLEAN MODE) and is_active = 1 GROUP BY title ORDER BY competition_rate LIMIT 20", nativeQuery = true)
     List<Campaign> searchByTitleFullText(@Param("keyword") String keyword);
 
-    // 키워드 맞춤형 캠페인 FULLTEXT 검색 (Natural Language Mode - 성능 최적화)
+    // 키워드 맞춤형 캠페인 FULLTEXT 검색 (지정 날짜 기준 전일)
     @Query(value = """
         SELECT * FROM campaigns 
         WHERE MATCH(title) AGAINST(:keyword)
         AND is_active = 1 
+        AND DATE(created_at) = DATE(:date - INTERVAL 1 DAY)
         ORDER BY MATCH(title) AGAINST(:keyword) DESC, created_at DESC
         LIMIT :offset, :limit
         """, nativeQuery = true)
     List<Campaign> findByKeywordFullText(
         @Param("keyword") String keyword, 
+        @Param("date") LocalDate date,
         @Param("offset") int offset, 
         @Param("limit") int limit
     );
     
-    // 키워드 맞춤형 캠페인 FULLTEXT 검색 개수
+    // 지정 날짜 기준 전일 생성된 키워드 맞춤형 캠페인 개수
     @Query(value = """
         SELECT COUNT(*) FROM campaigns 
         WHERE MATCH(title) AGAINST(:keyword)
         AND is_active = 1 
-        """, nativeQuery = true)
-    long countByKeywordFullText(@Param("keyword") String keyword);
-    
-    // 특정 날짜에 생성된 키워드 맞춤형 캠페인 개수 (신규 증가분 계산용)
-    @Query(value = """
-        SELECT COUNT(*) FROM campaigns 
-        WHERE MATCH(title) AGAINST(:keyword)
-        AND is_active = 1 
-        AND DATE(created_at) = :date
+        AND DATE(created_at) = DATE(:date - INTERVAL 1 DAY)
         """, nativeQuery = true)
     long countByKeywordAndCreatedDate(@Param("keyword") String keyword, @Param("date") LocalDate date);
 } 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignService.java
@@ -35,9 +35,7 @@ public interface CampaignService {
 
     PageListResponseDTO<CampaignResponseDTO> searchByKeyword(String keyword, Pageable pageable, Long userId);
 
-    Page<CampaignResponseDTO> getPersonalizedCampaignsByKeyword(Long userId, String keyword, Pageable pageable);
-
-    long getCampaignCountByKeyword(String keyword);
+    Page<CampaignResponseDTO> getPersonalizedCampaignsByKeyword(String keyword, LocalDate date, Pageable pageable);
     
     long getDailyCampaignCountByKeyword(String keyword, LocalDate date);
 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
@@ -146,16 +146,17 @@ public class CampaignServiceImpl implements CampaignService {
      */
     @Override
     @PerformanceMonitor
-    public Page<CampaignResponseDTO> getPersonalizedCampaignsByKeyword(Long userId, String keyword, Pageable pageable) {
+    public Page<CampaignResponseDTO> getPersonalizedCampaignsByKeyword(String keyword, LocalDate date, Pageable pageable) {
         
         // 기존 방식으로 되돌림 (Object[] 매핑 복잡성으로 인해)
         List<Campaign> campaigns = campaignRepository.findByKeywordFullText(
-            keyword.trim(), 
+            keyword.trim(),
+            date, 
             (int) pageable.getOffset(), 
             pageable.getPageSize()
         );
         
-        long totalElements = campaignRepository.countByKeywordFullText(keyword.trim());
+        long totalElements = campaignRepository.countByKeywordAndCreatedDate(keyword.trim(), date);
         
         // DTO 변환
         List<CampaignResponseDTO> content = campaigns.stream()
@@ -163,15 +164,6 @@ public class CampaignServiceImpl implements CampaignService {
             .collect(Collectors.toList());
             
         return new PageImpl<>(content, pageable, totalElements);
-    }
-
-    @Override
-    @PerformanceMonitor
-    public long getCampaignCountByKeyword(String keyword) {
-        if (keyword == null || keyword.trim().isEmpty()) {
-            return 0;
-        }
-        return campaignRepository.countByKeywordFullText(keyword.trim());
     }
     
     @Override

--- a/src/main/java/com/example/cherrydan/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/example/cherrydan/notification/scheduler/NotificationScheduler.java
@@ -38,9 +38,9 @@ public class NotificationScheduler {
     }
     
     /**
-     * 매일 오전 10시 30분에 실행 - 키워드 맞춤 알림 발송
+     * 10분마다 실행 - 키워드 맞춤 알림 발송 (테스트용)
      */
-    @Scheduled(cron = "0 30 10 * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 */10 * * * ?", zone = "Asia/Seoul")
     public void sendDailyKeywordNotifications() {
         log.info("=== 일일 키워드 맞춤 알림 발송 작업 시작 ===");
         
@@ -56,9 +56,9 @@ public class NotificationScheduler {
     }
 
     /**
-     * 매일 새벽 7시에 실행 - 키워드 맞춤 알림 대상 업데이트 (배치 처리)
+     * 10분마다 실행 - 키워드 맞춤 알림 대상 업데이트 (테스트용, 알림 발송보다 먼저)
      */
-    @Scheduled(cron = "0 0 7 * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 5/10 * * * ?", zone = "Asia/Seoul")
     public void updateKeywordCampaignAlerts() {
         log.info("=== 새벽 키워드 알림 업데이트 작업 시작 ===");
         

--- a/src/main/java/com/example/cherrydan/user/controller/UserKeywordController.java
+++ b/src/main/java/com/example/cherrydan/user/controller/UserKeywordController.java
@@ -18,6 +18,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -132,9 +135,10 @@ public class UserKeywordController {
     public ApiResponse<PageListResponseDTO<CampaignResponseDTO>> getPersonalizedCampaignsByKeyword(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestParam("keyword") String keyword,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @PageableDefault(size = 20) Pageable pageable
     ) {
-        Page<CampaignResponseDTO> campaigns = userKeywordService.getPersonalizedCampaignsByKeyword(currentUser.getId(), keyword, pageable);
+        Page<CampaignResponseDTO> campaigns = userKeywordService.getPersonalizedCampaignsByKeyword(keyword, date, pageable);
         PageListResponseDTO<CampaignResponseDTO> response = PageListResponseDTO.from(campaigns);
         return ApiResponse.success("맞춤형 캠페인 조회 성공", response);
     }

--- a/src/main/java/com/example/cherrydan/user/dto/KeywordCampaignAlertResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/user/dto/KeywordCampaignAlertResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+import java.time.LocalDate;
 
 
 @Getter
@@ -27,6 +27,9 @@ public class KeywordCampaignAlertResponseDTO {
 
     @Schema(description = "매칭된 캠페인 수", example = "10")
     private Integer campaignCount;
+
+    @Schema(description = "알림 날짜", example = "2024-07-21")
+    private LocalDate alertDate;
     
     /**
      * 엔티티를 DTO로 변환
@@ -37,6 +40,7 @@ public class KeywordCampaignAlertResponseDTO {
                 .keyword(alert.getKeyword())
                 .isRead(alert.getIsRead())
                 .campaignCount(alert.getCampaignCount())
+                .alertDate(alert.getAlertDate())
                 .build();
     }
 } 

--- a/src/main/java/com/example/cherrydan/user/repository/UserKeywordRepository.java
+++ b/src/main/java/com/example/cherrydan/user/repository/UserKeywordRepository.java
@@ -19,14 +19,9 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
     
     @Query("SELECT uk FROM UserKeyword uk WHERE uk.id = :keywordId AND uk.user.id = :userId AND uk.user.isActive = true")
     Optional<UserKeyword> findByIdAndUserId(@Param("keywordId") Long keywordId, @Param("userId") Long userId);
-    
-    @Query("SELECT uk FROM UserKeyword uk WHERE uk.keyword = :keyword AND uk.user.isActive = true")
-    List<UserKeyword> findAllByKeyword(@Param("keyword") String keyword);
 
     @Query("SELECT COUNT(uk) > 0 FROM UserKeyword uk WHERE uk.user.id = :userId AND uk.keyword = :keyword AND uk.user.isActive = true")
     boolean existsByUserIdAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
-    
-    void deleteByUserIdAndKeyword(Long userId, String keyword);
 
     /**
      * 모든 사용자 키워드를 키워드별로 그룹핑하여 조회 (배치 최적화) - 활성 사용자만

--- a/src/main/java/com/example/cherrydan/user/service/KeywordProcessingService.java
+++ b/src/main/java/com/example/cherrydan/user/service/KeywordProcessingService.java
@@ -46,9 +46,8 @@ public class KeywordProcessingService {
         int failureCount = 0;
         
         try {
-            // 어제 하루 동안 생성된 캠페인 수 조회 (간단!)
-            LocalDate yesterday = today.minusDays(1);
-            long dailyNewCount = campaignService.getDailyCampaignCountByKeyword(keyword, yesterday);
+            // 지정 날짜 기준으로 생성된 캠페인 수 조회
+            long dailyNewCount = campaignService.getDailyCampaignCountByKeyword(keyword, today);
             
             // 신규 캠페인이 없으면 알림 생성하지 않음
             if (dailyNewCount == 0) {

--- a/src/main/java/com/example/cherrydan/user/service/UserKeywordService.java
+++ b/src/main/java/com/example/cherrydan/user/service/UserKeywordService.java
@@ -183,12 +183,8 @@ public class UserKeywordService {
      * 특정 키워드로 맞춤형 캠페인 목록 조회
      */
     @Transactional(readOnly = true)
-    public Page<CampaignResponseDTO> getPersonalizedCampaignsByKeyword(Long userId, String keyword, Pageable pageable) {
-        // 해당 유저가 등록한 키워드인지 검증
-        if (!userKeywordRepository.existsByUserIdAndKeyword(userId, keyword)) {
-            throw new UserException(ErrorMessage.USER_KEYWORD_NOT_FOUND);
-        }
-        return campaignService.getPersonalizedCampaignsByKeyword(userId, keyword, pageable);
+    public Page<CampaignResponseDTO> getPersonalizedCampaignsByKeyword(String keyword, LocalDate date, Pageable pageable) {
+        return campaignService.getPersonalizedCampaignsByKeyword(keyword, date, pageable);
     }
 
     /**

--- a/src/test/java/com/example/cherrydan/user/service/UserKeywordServiceAsyncTest.java
+++ b/src/test/java/com/example/cherrydan/user/service/UserKeywordServiceAsyncTest.java
@@ -172,7 +172,7 @@ class UserKeywordServiceAsyncTest {
         // When & Then
         testKeywords.forEach(keyword -> {
             long startTime = System.currentTimeMillis();
-            long campaignCount = campaignService.getCampaignCountByKeyword(keyword);
+            long campaignCount = campaignService.getDailyCampaignCountByKeyword(keyword, LocalDate.of(2025, 7, 20)); // 어제 날짜로 고정
             long endTime = System.currentTimeMillis();
             
             log.info("키워드 '{}': {}개 캠페인, 조회 시간: {}ms", 


### PR DESCRIPTION
- CampaignRepository에 날짜 매개변수를 받아서 전일 기준으로 캠페인을 조회하는 쿼리를 수정했습니다
- CampaignService와 CampaignServiceImpl에서 날짜 매개변수를 지원하도록 메서드 시그니처를 변경했습니다
