### PR TITLE
Feat: 7개 체험단 사이트 Enum 추가

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/domain/CampaignPlatformType.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/CampaignPlatformType.java
@@ -14,7 +14,14 @@ public enum CampaignPlatformType {
     DINNERQUEEN("dinnerqueen", "디너의여왕"),
     SEOULOUBA("seoulouba", "서울오빠"),
     COMETOPLAY("cometoplay", "놀러와체험단"),
-    GANGNAM("gangnam", "강남맛집");
+    GANGNAM("gangnam", "강남맛집"),
+    MRBLOG("mrblog", "미블"),
+    WHOGIUP("whogiup", "후기업"),
+    WEU("weu", "위우"),
+    TBLE("tble", "티블"),
+    STORYN("storyn", "스토리앤미디어"),
+    REVIEWPLACE("reviewplace", "리뷰플레이스"),
+    BLOGDEXREVIEW("blogdexreview", "블덱스체험단");
 
     private final String code;
     private final String label;


### PR DESCRIPTION
# Pull Request: Feat: 7개 체험단 사이트 Enum 추가

## 관련 이슈

## 변경 사항 요약
- 7개 체험단 사이트 Enum 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for seven new campaign platform types, expanding the available options for campaign categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->