### PR TITLE
Feat: 기존 북마크 조회 API -> 마감, 미마감 API 2개로 분리

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
@@ -52,26 +52,29 @@ public class BookmarkController {
     }
 
     @Operation(
-        summary = "내 북마크 목록 조회", 
-        description = """
-            내가 북마크(찜)한 캠페인 목록을 조회합니다.
-            
-            **쿼리 파라미터 예시:**
-            - ?page=0&size=20
-            - ?page=1&size=10
-            
-            **정렬**: 북마크 생성 시각 내림차순 (고정)
-            
-            **주의:** 이는 Request Body가 아닌 **Query Parameter**입니다.
-            """
+        summary = "오늘+기간 남은 북마크 목록 조회",
+        description = "오늘 이후 reviewerAnnouncement가 남아있는 북마크 목록을 조회합니다."
     )
-    @GetMapping("/bookmarks")
-    public ResponseEntity<ApiResponse<BookmarkSplitResponseDTO>> getBookmarks(
+    @GetMapping("/bookmarks/open")
+    public ResponseEntity<ApiResponse<PageListResponseDTO<BookmarkResponseDTO>>> getOpenBookmarks(
             @AuthenticationPrincipal UserDetailsImpl currentUser,
             Pageable pageable
     ) {
-        BookmarkSplitResponseDTO result = bookmarkService.getBookmarks(currentUser.getId(), pageable);
-        return ResponseEntity.ok(ApiResponse.success("북마크 목록 조회 성공", result));
+        PageListResponseDTO<BookmarkResponseDTO> result = bookmarkService.getOpenBookmarks(currentUser.getId(), pageable);
+        return ResponseEntity.ok(ApiResponse.success("기간 남은 북마크 목록 조회 성공", result));
+    }
+
+    @Operation(
+        summary = "기간 지난 북마크 목록 조회",
+        description = "오늘 이전 reviewerAnnouncement가 지난 북마크 목록을 조회합니다."
+    )
+    @GetMapping("/bookmarks/closed")
+    public ResponseEntity<ApiResponse<PageListResponseDTO<BookmarkResponseDTO>>> getClosedBookmarks(
+            @AuthenticationPrincipal UserDetailsImpl currentUser,
+            Pageable pageable
+    ) {
+        PageListResponseDTO<BookmarkResponseDTO> result = bookmarkService.getClosedBookmarks(currentUser.getId(), pageable);
+        return ResponseEntity.ok(ApiResponse.success("기간 지난 북마크 목록 조회 성공", result));
     }
 
     @Operation(summary = "북마크 완전 삭제", description = "캠페인 북마크(찜) 정보를 완전히 삭제합니다.")

--- a/src/main/java/com/example/cherrydan/campaign/repository/BookmarkRepository.java
+++ b/src/main/java/com/example/cherrydan/campaign/repository/BookmarkRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDate;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByUserAndCampaign(User user, Campaign campaign);
@@ -17,4 +18,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     void deleteByUserAndCampaign(User user, Campaign campaign);
     boolean existsByUserIdAndCampaignIdAndIsActiveTrue(Long userId, Long campaignId);
     List<Bookmark> findAllByUserIdAndIsActiveTrue(Long userId);
+    Page<Bookmark> findByUserIdAndIsActiveTrueAndCampaign_ReviewerAnnouncementGreaterThanEqual(Long userId, LocalDate date, Pageable pageable);
+    Page<Bookmark> findByUserIdAndIsActiveTrueAndCampaign_ReviewerAnnouncementLessThan(Long userId, LocalDate date, Pageable pageable);
 } 

--- a/src/main/java/com/example/cherrydan/campaign/service/BookmarkService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/BookmarkService.java
@@ -1,12 +1,14 @@
 package com.example.cherrydan.campaign.service;
 
-import com.example.cherrydan.campaign.dto.BookmarkSplitResponseDTO;
+import com.example.cherrydan.campaign.dto.BookmarkResponseDTO;
+import com.example.cherrydan.common.response.PageListResponseDTO;
 import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface BookmarkService {
     void addBookmark(Long userId, Long campaignId);
     void cancelBookmark(Long userId, Long campaignId);
-    BookmarkSplitResponseDTO getBookmarks(Long userId, Pageable pageable);
+    PageListResponseDTO<BookmarkResponseDTO> getOpenBookmarks(Long userId, Pageable pageable);
+    PageListResponseDTO<BookmarkResponseDTO> getClosedBookmarks(Long userId, Pageable pageable);
     void deleteBookmark(Long userId, Long campaignId);
 } 


### PR DESCRIPTION
# Pull Request: Feat: 기존 북마크 조회 API -> 마감, 미마감 API 2개로 분리

## 관련 이슈

## 변경 사항 요약
- 기존 북마크 API 1개로 페이지네이션 처리하기가 어려움이 있어, 마감/미마감 2개 API로 분리