### PR TITLE
Feat: 중복 방지 unique 설정 및 성능 향상을 위한 index 추가

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/domain/Bookmark.java
+++ b/src/main/java/com/example/cherrydan/campaign/domain/Bookmark.java
@@ -6,7 +6,14 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "campaign_bookmark")
+@Table(name = "campaign_bookmark",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "campaign_id"})
+    },
+    indexes = {
+        @Index(name = "idx_campaign_bookmark_user_active", columnList = "user_id, is_active")
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor


### PR DESCRIPTION
# Pull Request: Feat: 중복 방지 unique 설정 및 성능 향상을 위한 index 추가

## 관련 이슈

## 변경 사항 요약
- 중복 방지 unique 설정 `user_id, campaign_id`
- 성능 향상을 위한 index 추가 `user_id, is_active`

## 변경 이유
- 병주가 직접 경험한 케이스인데, 거의 중복으로 데이터가 저장된 이슈가 존재해서 이를 방지하고자 세팅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prevents users from bookmarking the same campaign more than once.
  * Improves performance for queries filtering bookmarks by user and active status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->