### PR TITLE
feat: fcm test logic add

### DIFF
--- a/src/main/java/com/example/cherrydan/fcm/domain/UserFCMToken.java
+++ b/src/main/java/com/example/cherrydan/fcm/domain/UserFCMToken.java
@@ -38,7 +38,7 @@ public class UserFCMToken extends BaseTimeEntity {
     /**
      * FCM 토큰 (디바이스별로 고유)
      */
-    @Column(name = "fcm_token", nullable = false, length = 500)
+    @Column(name = "fcm_token", length = 500)
     private String fcmToken;
 
     /**
@@ -51,7 +51,7 @@ public class UserFCMToken extends BaseTimeEntity {
      * 디바이스 타입 (android, ios)
      */
     @Enumerated(EnumType.STRING)
-    @Column(name = "device_type", nullable = false, length = 10)
+    @Column(name = "device_type", length = 10)
     private DeviceType deviceType;
 
     @Column(name = "app_version")
@@ -64,7 +64,7 @@ public class UserFCMToken extends BaseTimeEntity {
     /**
      * 토큰 활성화 상태
      */
-    @Column(name = "is_active", nullable = false)
+    @Column(name = "is_active")
     private Boolean isActive;
 
     /**
@@ -78,8 +78,9 @@ public class UserFCMToken extends BaseTimeEntity {
      * @param request FCM 토큰 요청 정보
      */
     public void updateToken(FCMTokenRequest request) {
-        this.fcmToken = request.getFcmToken();
-        this.lastUsedAt = LocalDateTime.now();
+        if (request.getFcmToken() != null && !request.getFcmToken().trim().isEmpty()) {
+            this.fcmToken = request.getFcmToken();
+        }
         
         // 디바이스 타입 업데이트
         if (request.getDeviceType() != null && !request.getDeviceType().trim().isEmpty()) {

--- a/src/main/java/com/example/cherrydan/fcm/repository/UserFCMTokenRepository.java
+++ b/src/main/java/com/example/cherrydan/fcm/repository/UserFCMTokenRepository.java
@@ -24,12 +24,20 @@ import java.util.Optional;
 public interface UserFCMTokenRepository extends JpaRepository<UserFCMToken, Long> {
     
     /**
-     * 사용자 ID로 활성화된 모든 토큰 조회
+     * 사용자 ID로 활성화된 모든 디바이스 조회 (FCM 토큰이 있는 것만)
      * @param userId 사용자 ID
-     * @return 활성화된 FCM 토큰 리스트
+     * @return FCM 토큰이 있고 활성화된 디바이스 리스트
+     */
+    @Query("SELECT t FROM UserFCMToken t WHERE t.userId = :userId AND t.fcmToken IS NOT NULL AND t.isActive = true")
+    List<UserFCMToken> findActiveTokensByUserId(@Param("userId") Long userId);
+    
+    /**
+     * 사용자 ID로 활성화된 모든 디바이스 조회 (FCM 토큰 유무와 관계없이)
+     * @param userId 사용자 ID
+     * @return 활성화된 모든 디바이스 리스트
      */
     @Query("SELECT t FROM UserFCMToken t WHERE t.userId = :userId AND t.isActive = true")
-    List<UserFCMToken> findActiveTokensByUserId(@Param("userId") Long userId);
+    List<UserFCMToken> findActiveDevicesByUserId(@Param("userId") Long userId);
     
     /**
      * 사용자 ID와 디바이스 타입으로 토큰 조회
@@ -51,38 +59,6 @@ public interface UserFCMTokenRepository extends JpaRepository<UserFCMToken, Long
      * @param userIds 사용자 ID 리스트
      * @return 활성화된 FCM 토큰 리스트
      */
-    @Query("SELECT t FROM UserFCMToken t WHERE t.userId IN :userIds AND t.isActive = true")
+    @Query("SELECT t FROM UserFCMToken t WHERE t.userId IN :userIds AND t.fcmToken IS NOT NULL AND t.isActive = true")
     List<UserFCMToken> findActiveTokensByUserIds(@Param("userIds") List<Long> userIds);
-
-    
-    /**
-     * 마지막 사용 시간이 특정 기간 이전인 토큰들 조회 (정리용)
-     * @param dateTime 기준 시간
-     * @return 오래된 FCM 토큰 리스트
-     */
-    @Query("SELECT t FROM UserFCMToken t WHERE t.lastUsedAt < :dateTime AND t.isActive = true")
-    List<UserFCMToken> findTokensNotUsedSince(@Param("dateTime") LocalDateTime dateTime);
-    
-    /**
-     * 특정 FCM 토큰 비활성화
-     * @param fcmToken FCM 토큰
-     */
-    @Modifying
-    @Query("UPDATE UserFCMToken t SET t.isActive = false WHERE t.fcmToken = :fcmToken")
-    void deactivateByFcmToken(@Param("fcmToken") String fcmToken);
-    
-    /**
-     * 사용자의 모든 토큰 비활성화
-     * @param userId 사용자 ID
-     */
-    @Modifying
-    @Query("UPDATE UserFCMToken t SET t.isActive = false WHERE t.userId = :userId")
-    void deactivateAllTokensByUserId(@Param("userId") Long userId);
-    
-    /**
-     * 사용자 ID로 토큰 존재 여부 확인
-     * @param userId 사용자 ID
-     * @return 토큰 존재 여부
-     */
-    boolean existsByUserIdAndIsActiveTrue(Long userId);
 }

--- a/src/test/java/com/example/cherrydan/fcm/service/FCMTokenServiceTest.java
+++ b/src/test/java/com/example/cherrydan/fcm/service/FCMTokenServiceTest.java
@@ -1,0 +1,292 @@
+package com.example.cherrydan.fcm.service;
+
+import com.example.cherrydan.fcm.domain.DeviceType;
+import com.example.cherrydan.fcm.domain.UserFCMToken;
+import com.example.cherrydan.fcm.dto.FCMTokenRequest;
+import com.example.cherrydan.fcm.repository.UserFCMTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("local")
+@Transactional
+@DisplayName("FCMTokenService 통합테스트")
+class FCMTokenServiceTest {
+
+    @Autowired
+    private UserFCMTokenRepository tokenRepository;
+
+    @Autowired
+    private FCMTokenService fcmTokenService;
+
+    private FCMTokenRequest fcmTokenRequest;
+
+    @BeforeEach
+    void setUp() {
+        fcmTokenRequest = FCMTokenRequest.builder()
+                .userId(1L)
+                .fcmToken("test-fcm-token")
+                .deviceType("android")
+                .deviceModel("Galaxy S23")
+                .appVersion("1.0.0")
+                .osVersion("13")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("FCM 토큰 등록/업데이트")
+    class RegisterOrUpdateToken {
+
+        @Test
+        @DisplayName("새로운 FCM 토큰이 성공적으로 등록된다")
+        void registerNewToken_Success() {
+            // when
+            fcmTokenService.registerOrUpdateToken(fcmTokenRequest);
+
+            // then
+            Optional<UserFCMToken> savedToken = tokenRepository.findByUserIdAndDeviceTypeAndIsActiveTrue(
+                    fcmTokenRequest.getUserId(), DeviceType.ANDROID);
+            
+            assertThat(savedToken).isPresent();
+            assertThat(savedToken.get().getFcmToken()).isEqualTo("test-fcm-token");
+            assertThat(savedToken.get().getDeviceModel()).isEqualTo("Galaxy S23");
+            assertThat(savedToken.get().getAppVersion()).isEqualTo("1.0.0");
+            assertThat(savedToken.get().getOsVersion()).isEqualTo("13");
+            assertThat(savedToken.get().getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("기존 FCM 토큰이 성공적으로 업데이트된다")
+        void updateExistingToken_Success() {
+            // given
+            UserFCMToken existingToken = tokenRepository.save(UserFCMToken.builder()
+                    .userId(1L)
+                    .fcmToken("existing-fcm-token")
+                    .deviceType(DeviceType.ANDROID)
+                    .deviceModel("Galaxy S22")
+                    .appVersion("0.9.0")
+                    .osVersion("12")
+                    .isActive(true)
+                    .lastUsedAt(LocalDateTime.now().minusDays(1))
+                    .build());
+
+            // when
+            fcmTokenService.registerOrUpdateToken(fcmTokenRequest);
+
+            // then
+            UserFCMToken updatedToken = tokenRepository.findById(existingToken.getId()).orElseThrow();
+            assertThat(updatedToken.getFcmToken()).isEqualTo("test-fcm-token");
+            assertThat(updatedToken.getDeviceModel()).isEqualTo("Galaxy S23");
+            assertThat(updatedToken.getAppVersion()).isEqualTo("1.0.0");
+            assertThat(updatedToken.getOsVersion()).isEqualTo("13");
+            assertThat(updatedToken.getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("FCM 토큰이 null이어도 디바이스 정보가 저장된다")
+        void registerDeviceInfoWithNullToken_Success() {
+            // given
+            FCMTokenRequest nullTokenRequest = FCMTokenRequest.builder()
+                    .userId(2L)
+                    .fcmToken(null)
+                    .deviceType("ios")
+                    .deviceModel("iPhone 14 Pro")
+                    .appVersion("2.0.0")
+                    .osVersion("16")
+                    .build();
+
+            // when
+            fcmTokenService.registerOrUpdateToken(nullTokenRequest);
+
+            // then
+            Optional<UserFCMToken> savedToken = tokenRepository.findByUserIdAndDeviceTypeAndIsActiveTrue(
+                    2L, DeviceType.IOS);
+            
+            assertThat(savedToken).isPresent();
+            assertThat(savedToken.get().getFcmToken()).isNull();
+            assertThat(savedToken.get().getDeviceType()).isEqualTo(DeviceType.IOS);
+            assertThat(savedToken.get().getDeviceModel()).isEqualTo("iPhone 14 Pro");
+            assertThat(savedToken.get().getAppVersion()).isEqualTo("2.0.0");
+            assertThat(savedToken.get().getOsVersion()).isEqualTo("16");
+            assertThat(savedToken.get().getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("FCM 토큰이 빈 문자열이어도 디바이스 정보가 저장된다")
+        void registerDeviceInfoWithEmptyToken_Success() {
+            // given
+            FCMTokenRequest emptyTokenRequest = FCMTokenRequest.builder()
+                    .userId(3L)
+                    .fcmToken(null)
+                    .deviceType("android")
+                    .deviceModel("Pixel 7")
+                    .appVersion("1.5.0")
+                    .osVersion("13")
+                    .build();
+
+            // when
+            fcmTokenService.registerOrUpdateToken(emptyTokenRequest);
+
+            // then
+            Optional<UserFCMToken> savedToken = tokenRepository.findByUserIdAndDeviceTypeAndIsActiveTrue(
+                    3L, DeviceType.ANDROID);
+            
+            assertThat(savedToken).isPresent();
+            assertThat(savedToken.get().getFcmToken()).isNull();
+            assertThat(savedToken.get().getDeviceType()).isEqualTo(DeviceType.ANDROID);
+            assertThat(savedToken.get().getDeviceModel()).isEqualTo("Pixel 7");
+            assertThat(savedToken.get().getAppVersion()).isEqualTo("1.5.0");
+            assertThat(savedToken.get().getOsVersion()).isEqualTo("13");
+        }
+
+        @Test
+        @DisplayName("잘못된 디바이스 타입으로 예외가 발생해도 처리된다")
+        void handleInvalidDeviceType() {
+            // given
+            FCMTokenRequest invalidDeviceRequest = FCMTokenRequest.builder()
+                    .userId(4L)
+                    .fcmToken("test-token")
+                    .deviceType("invalid-device")
+                    .deviceModel("Test Device")
+                    .appVersion("1.0.0")
+                    .osVersion("1.0")
+                    .build();
+
+            // when & then
+            assertThatCode(() -> fcmTokenService.registerOrUpdateToken(invalidDeviceRequest))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("FCM 토큰 조회")
+    class FindTokens {
+
+        @Test
+        @DisplayName("FCM 토큰이 있는 디바이스만 조회된다")
+        void findActiveTokensByUserId_OnlyWithTokens() {
+            // given
+            Long userId = 20L;
+            
+            // FCM 토큰이 있는 디바이스
+            tokenRepository.save(UserFCMToken.builder()
+                    .userId(userId)
+                    .fcmToken("valid-token-1")
+                    .deviceType(DeviceType.ANDROID)
+                    .deviceModel("Galaxy S23")
+                    .isActive(true)
+                    .build());
+                    
+            // FCM 토큰이 null인 디바이스
+            tokenRepository.save(UserFCMToken.builder()
+                    .userId(userId)
+                    .fcmToken(null)
+                    .deviceType(DeviceType.IOS)
+                    .deviceModel("iPhone 14")
+                    .isActive(true)
+                    .build());
+                    
+            // FCM 토큰이 있는 다른 디바이스
+            tokenRepository.save(UserFCMToken.builder()
+                    .userId(userId)
+                    .fcmToken("valid-token-2")
+                    .deviceType(DeviceType.ANDROID)
+                    .deviceModel("Pixel 8")
+                    .isActive(true)
+                    .build());
+
+            // when
+            List<UserFCMToken> tokensWithFcm = tokenRepository.findActiveTokensByUserId(userId);
+            List<UserFCMToken> allDevices = tokenRepository.findActiveDevicesByUserId(userId);
+
+            // then
+            assertThat(tokensWithFcm).hasSize(2);
+            assertThat(tokensWithFcm).allMatch(token -> token.getFcmToken() != null);
+            assertThat(allDevices).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("여러 사용자의 FCM 토큰이 있는 디바이스만 조회된다")
+        void findActiveTokensByUserIds_OnlyWithTokens() {
+            // given
+            Long userId1 = 21L;
+            Long userId2 = 22L;
+            
+            // 사용자1 - FCM 토큰 있음
+            tokenRepository.save(UserFCMToken.builder()
+                    .userId(userId1)
+                    .fcmToken("user1-token")
+                    .deviceType(DeviceType.ANDROID)
+                    .isActive(true)
+                    .build());
+                    
+            // 사용자1 - FCM 토큰 null
+            tokenRepository.save(UserFCMToken.builder()
+                    .userId(userId1)
+                    .fcmToken(null)
+                    .deviceType(DeviceType.IOS)
+                    .isActive(true)
+                    .build());
+                    
+            // 사용자2 - FCM 토큰 있음
+            tokenRepository.save(UserFCMToken.builder()
+                    .userId(userId2)
+                    .fcmToken("user2-token")
+                    .deviceType(DeviceType.IOS)
+                    .isActive(true)
+                    .build());
+
+            // when
+            List<UserFCMToken> tokens = tokenRepository.findActiveTokensByUserIds(List.of(userId1, userId2));
+
+            // then
+            assertThat(tokens).hasSize(2);
+            assertThat(tokens).allMatch(token -> token.getFcmToken() != null);
+            assertThat(tokens).extracting(UserFCMToken::getUserId)
+                    .containsExactlyInAnyOrder(userId1, userId2);
+        }
+
+        @Test
+        @DisplayName("비활성화된 디바이스는 조회되지 않는다")
+        void findActiveTokensByUserId_OnlyActiveDevices() {
+            // given
+            Long userId = 23L;
+            
+            // 활성화된 디바이스
+            tokenRepository.save(UserFCMToken.builder()
+                    .userId(userId)
+                    .fcmToken("active-token")
+                    .deviceType(DeviceType.ANDROID)
+                    .isActive(true)
+                    .build());
+                    
+            // 비활성화된 디바이스
+            tokenRepository.save(UserFCMToken.builder()
+                    .userId(userId)
+                    .fcmToken("inactive-token")
+                    .deviceType(DeviceType.IOS)
+                    .isActive(false)
+                    .build());
+
+            // when
+            List<UserFCMToken> tokens = tokenRepository.findActiveTokensByUserId(userId);
+
+            // then
+            assertThat(tokens).hasSize(1);
+            assertThat(tokens.get(0).getFcmToken()).isEqualTo("active-token");
+            assertThat(tokens.get(0).getIsActive()).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/example/cherrydan/oauth/security/oauth2/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/example/cherrydan/oauth/security/oauth2/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,149 @@
+package com.example.cherrydan.oauth.security.oauth2;
+
+import com.example.cherrydan.fcm.domain.DeviceType;
+import com.example.cherrydan.fcm.domain.UserFCMToken;
+import com.example.cherrydan.fcm.repository.UserFCMTokenRepository;
+import com.example.cherrydan.oauth.dto.AppleLoginRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("local")
+@Transactional
+@DisplayName("CustomOAuth2UserService FCM 관련 통합테스트")
+class CustomOAuth2UserServiceTest {
+
+    @Autowired
+    private UserFCMTokenRepository tokenRepository;
+
+    @Autowired
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    private AppleLoginRequest loginRequest;
+
+    @BeforeEach
+    void setUp() {
+        loginRequest = new AppleLoginRequest();
+        loginRequest.setFcmToken("test-fcm-token");
+        loginRequest.setDeviceType("android");
+        loginRequest.setDeviceModel("Galaxy S23");
+        loginRequest.setAppVersion("1.0.0");
+        loginRequest.setOsVersion("13");
+    }
+
+    @Nested
+    @DisplayName("FCM 토큰 등록 테스트")
+    class RegisterFCMTokenIfPresent {
+
+        @Test
+        @DisplayName("FCM 토큰이 있을 때 성공적으로 등록된다")
+        void registerFCMToken_WithValidToken_Success() {
+            // given
+            Long userId = 1L;
+
+            // when
+            customOAuth2UserService.registerFCMTokenIfPresent(userId, loginRequest);
+
+            // then
+            Optional<UserFCMToken> savedToken = tokenRepository.findByUserIdAndDeviceTypeAndIsActiveTrue(
+                    userId, DeviceType.ANDROID);
+            
+            assertThat(savedToken).isPresent();
+            assertThat(savedToken.get().getFcmToken()).isEqualTo("test-fcm-token");
+            assertThat(savedToken.get().getDeviceModel()).isEqualTo("Galaxy S23");
+            assertThat(savedToken.get().getAppVersion()).isEqualTo("1.0.0");
+            assertThat(savedToken.get().getOsVersion()).isEqualTo("13");
+        }
+
+        @Test
+        @DisplayName("FCM 토큰이 null일 때도 디바이스 정보는 저장된다")
+        void registerDeviceInfo_WithNullToken_Success() {
+            // given
+            Long userId = 2L;
+            AppleLoginRequest nullTokenRequest = new AppleLoginRequest();
+            nullTokenRequest.setFcmToken(null);
+            nullTokenRequest.setDeviceType("ios");
+            nullTokenRequest.setDeviceModel("iPhone 14 Pro");
+            nullTokenRequest.setAppVersion("2.0.0");
+            nullTokenRequest.setOsVersion("16");
+
+            // when
+            customOAuth2UserService.registerFCMTokenIfPresent(userId, nullTokenRequest);
+
+            // then
+            Optional<UserFCMToken> savedToken = tokenRepository.findByUserIdAndDeviceTypeAndIsActiveTrue(
+                    userId, DeviceType.IOS);
+            
+            assertThat(savedToken).isPresent();
+            assertThat(savedToken.get().getFcmToken()).isNull();
+            assertThat(savedToken.get().getDeviceType()).isEqualTo(DeviceType.IOS);
+            assertThat(savedToken.get().getDeviceModel()).isEqualTo("iPhone 14 Pro");
+            assertThat(savedToken.get().getAppVersion()).isEqualTo("2.0.0");
+            assertThat(savedToken.get().getOsVersion()).isEqualTo("16");
+        }
+
+        @Test
+        @DisplayName("FCM 토큰이 빈 문자열일 때도 디바이스 정보는 저장된다")
+        void registerDeviceInfo_WithEmptyToken_Success() {
+            // given
+            Long userId = 3L;
+            AppleLoginRequest emptyTokenRequest = new AppleLoginRequest();
+            emptyTokenRequest.setFcmToken("");
+            emptyTokenRequest.setDeviceType("android");
+            emptyTokenRequest.setDeviceModel("Pixel 7");
+            emptyTokenRequest.setAppVersion("1.5.0");
+            emptyTokenRequest.setOsVersion("13");
+
+            // when
+            customOAuth2UserService.registerFCMTokenIfPresent(userId, emptyTokenRequest);
+
+            // then
+            Optional<UserFCMToken> savedToken = tokenRepository.findByUserIdAndDeviceTypeAndIsActiveTrue(
+                    userId, DeviceType.ANDROID);
+            
+            assertThat(savedToken).isPresent();
+            assertThat(savedToken.get().getFcmToken()).isNull();
+            assertThat(savedToken.get().getDeviceType()).isEqualTo(DeviceType.ANDROID);
+            assertThat(savedToken.get().getDeviceModel()).isEqualTo("Pixel 7");
+            assertThat(savedToken.get().getAppVersion()).isEqualTo("1.5.0");
+            assertThat(savedToken.get().getOsVersion()).isEqualTo("13");
+        }
+
+        @Test
+        @DisplayName("FCM 토큰이 공백만 있을 때도 디바이스 정보는 저장된다")
+        void registerDeviceInfo_WithWhitespaceToken_Success() {
+            // given
+            Long userId = 4L;
+            AppleLoginRequest whitespaceTokenRequest = new AppleLoginRequest();
+            whitespaceTokenRequest.setFcmToken("   ");
+            whitespaceTokenRequest.setDeviceType("android");
+            whitespaceTokenRequest.setDeviceModel("OnePlus 10");
+            whitespaceTokenRequest.setAppVersion("1.2.0");
+            whitespaceTokenRequest.setOsVersion("12");
+
+            // when
+            customOAuth2UserService.registerFCMTokenIfPresent(userId, whitespaceTokenRequest);
+
+            // then
+            Optional<UserFCMToken> savedToken = tokenRepository.findByUserIdAndDeviceTypeAndIsActiveTrue(
+                    userId, DeviceType.ANDROID);
+            
+            assertThat(savedToken).isPresent();
+            assertThat(savedToken.get().getFcmToken()).isNull();
+            assertThat(savedToken.get().getDeviceModel()).isEqualTo("OnePlus 10");
+            assertThat(savedToken.get().getAppVersion()).isEqualTo("1.2.0");
+            assertThat(savedToken.get().getOsVersion()).isEqualTo("12");
+        }
+    }
+
+}


### PR DESCRIPTION
## 변경사항
- fcm이 없어도 유저 디바이스 정보가 저장되게 수정했습니다.
- 운영계와 개발계 DB에서 FCM의 not null 조건을 null 허용으로 수정했습니다.
- 테스트 로직 작성햇습니당.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Device information is now saved even when the push token is missing or empty.
  - Active token lists return only devices with valid tokens.
  - Added ability to view all active devices for a user (regardless of token).
- Bug Fixes
  - Prevented blank or null tokens from overwriting existing valid tokens during updates.
- Tests
  - Added integration tests covering device registration with/without tokens, updates, and active device/token retrieval across single and multi-user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->