### PR TITLE
Fix: 내 체험단 상태 조회 - 신청, 미신청 공고 기능 분리

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusService.java
@@ -14,6 +14,6 @@ public interface CampaignStatusService {
     CampaignStatusResponseDTO updateStatus(CampaignStatusRequestDTO requestDTO);
     void deleteStatus(Long campaignId, Long userId);
     CampaignStatusPopupResponseDTO getPopupStatusByUser(Long userId);
-    PageListResponseDTO<CampaignStatusResponseDTO> getStatusesByType(Long userId, CampaignStatusType statusType, Pageable pageable);
+    PageListResponseDTO<CampaignStatusResponseDTO> getStatusesByType(Long userId, CampaignStatusType statusType, String subFilter, Pageable pageable);
     CampaignStatusCountResponseDTO getStatusCounts(Long userId);
 } 

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusServiceImpl.java
@@ -144,10 +144,20 @@ public class CampaignStatusServiceImpl implements CampaignStatusService {
 
     @Override
     @Transactional(readOnly = true)
-    public PageListResponseDTO<CampaignStatusResponseDTO> getStatusesByType(Long userId, CampaignStatusType statusType, Pageable pageable) {
+    public PageListResponseDTO<CampaignStatusResponseDTO> getStatusesByType(Long userId, CampaignStatusType statusType, String subFilter, Pageable pageable) {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
-        Page<CampaignStatus> page = campaignStatusRepository.findByUserAndStatusAndIsActiveTrue(user, statusType, pageable);
+        
+        Page<CampaignStatus> page;
+        
+        // APPLY 상태이고 subFilter가 있는 경우 세부 필터링 적용
+        if (statusType == CampaignStatusType.APPLY && subFilter != null && !subFilter.trim().isEmpty()) {
+            LocalDate today = LocalDate.now();
+            page = campaignStatusRepository.findByUserAndStatusAndIsActiveTrueWithSubFilter(user, statusType, subFilter.trim(), today, pageable);
+        } else {
+            page = campaignStatusRepository.findByUserAndStatusAndIsActiveTrue(user, statusType, pageable);
+        }
+        
         List<CampaignStatusResponseDTO> content = page.getContent().stream()
                 .map(CampaignStatusResponseDTO::fromEntity)
                 .toList();

--- a/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
@@ -23,6 +23,7 @@ public enum ErrorMessage {
     CAMPAIGN_SNS_NOT_FOUND(NOT_FOUND, "존재하지 않는 SNS 플랫폼입니다."),
     CAMPAIGN_EXPERIENCE_PLATFORM_NOT_FOUND(NOT_FOUND, "존재하지 않는 체험단 플랫폼입니다."),
     CAMPAIGN_STATUS_INVALID(BAD_REQUEST, "유효하지 않은 상태값입니다."),
+    CAMPAIGN_STATUS_SUBFILTER_INVALID(BAD_REQUEST, "유효하지 않은 서브 필터값입니다."),
     
     // OAuth 관련 에러
     OAUTH_DUPLICATE_EMAIL(BAD_REQUEST, "이미 다른 소셜 계정으로 가입된 이메일입니다."),


### PR DESCRIPTION
# Pull Request: 내 체험단 상태 조회 - 신청, 미신청 공고 기능 분리

## 관련 이슈

## 변경 사항 요약
- 내 체험단 상태 조회 - `subFilter` 추가해 신청, 미신청 공고 기능 분리

## 변경 이유
- 페이지네이션 안되는 곳이 1곳 더 있는 것을 누락해 추가했습니다.