### PR TITLE
Fix: 내 체험단 상태 조회 네이밍 변경

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
@@ -32,7 +32,7 @@ import com.example.cherrydan.common.exception.ErrorMessage;
 public class CampaignStatusController {
     private final CampaignStatusService campaignStatusService;
 
-    @Operation(summary = "내 체험단 상태별 목록 조회", description = "status 파라미터(APPLY/SELECTED/NOT_SELECTED/REVIEWING/ENDED) 기준 페이지네이션, APPLY 상태의 경우 subFilter(open/close)로 기한 남은/지난 공고 필터링 가능")
+    @Operation(summary = "내 체험단 상태별 목록 조회", description = "status 파라미터(APPLY/SELECTED/NOT_SELECTED/REVIEWING/ENDED) 기준 페이지네이션, APPLY 상태의 경우 subFilter(waiting/completed)로 기한 남은/지난 공고 필터링 가능")
     @GetMapping
     public ResponseEntity<ApiResponse<PageListResponseDTO<CampaignStatusResponseDTO>>> getMyStatusesByType(
         @RequestParam(value = "status", defaultValue = "APPLY") String status,
@@ -48,10 +48,10 @@ public class CampaignStatusController {
             throw new CampaignException(ErrorMessage.CAMPAIGN_STATUS_INVALID);
         }
 
-        // APPLY 상태에서 subFilter가 주어졌다면 open/close만 허용
+        // APPLY 상태에서 subFilter가 주어졌다면 waiting/completed만 허용
         if (statusType == CampaignStatusType.APPLY && subFilter != null && !subFilter.trim().isEmpty()) {
             String sf = subFilter.trim().toLowerCase();
-            if (!sf.equals("open") && !sf.equals("close")) {
+            if (!sf.equals("waiting") && !sf.equals("completed")) {
                 throw new CampaignException(ErrorMessage.CAMPAIGN_STATUS_SUBFILTER_INVALID);
             }
         }

--- a/src/main/java/com/example/cherrydan/campaign/dto/BookmarkResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/BookmarkResponseDTO.java
@@ -18,6 +18,7 @@ import com.example.cherrydan.common.util.CloudfrontUtil;
 public class BookmarkResponseDTO {
     private Long id;
     private Long campaignId;
+    private Long userId;
     private String campaignTitle;
     private String campaignDetailUrl;
     private String campaignImageUrl;
@@ -34,6 +35,7 @@ public class BookmarkResponseDTO {
         String campaignPlatformImageUrl = CloudfrontUtil.getCampaignPlatformImageUrl(campaign.getSourceSite());
         return BookmarkResponseDTO.builder()
                 .id(bookmark.getId())
+                .userId(bookmark.getUser().getId())
                 .campaignId(campaign.getId())
                 .campaignTitle(campaign.getTitle())
                 .campaignDetailUrl(campaign.getDetailUrl())

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.example.cherrydan.common.util.CloudfrontUtil;
 import com.example.cherrydan.campaign.dto.BookmarkResponseDTO;
+import com.example.cherrydan.campaign.domain.CampaignStatus;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -60,7 +61,7 @@ public class CampaignStatusResponseDTO {
         return prefix + "D-Day"; 
     }
 
-    public static CampaignStatusResponseDTO fromEntity(com.example.cherrydan.campaign.domain.CampaignStatus status) {
+    public static CampaignStatusResponseDTO fromEntity(CampaignStatus status) {
         String reviewerAnnouncementStatus = null;
         switch (status.getStatus()) {
             case APPLY:

--- a/src/main/java/com/example/cherrydan/campaign/repository/CampaignStatusRepository.java
+++ b/src/main/java/com/example/cherrydan/campaign/repository/CampaignStatusRepository.java
@@ -25,13 +25,13 @@ public interface CampaignStatusRepository extends JpaRepository<CampaignStatus, 
     
     /**
      * APPLY 상태에 대한 세부 필터링 (기한 남은 공고 vs 기한 지난 공고)
-     * subFilter: "open" (기한 남은 공고), "close" (기한 지난 공고)
+     * subFilter: "waiting" (기한 남은 공고), "completed" (기한 지난 공고)
      */
     @Query("SELECT cs FROM CampaignStatus cs " +
            "JOIN FETCH cs.campaign c " +
            "WHERE cs.user = :user AND cs.status = :status AND cs.isActive = true " +
-           "AND (:subFilter = 'open' AND c.applyEnd > :today " +
-           "     OR :subFilter = 'close' AND c.applyEnd <= :today)")
+           "AND (:subFilter = 'waiting' AND c.applyEnd > :today " +
+           "     OR :subFilter = 'completed' AND c.applyEnd <= :today)")
     Page<CampaignStatus> findByUserAndStatusAndIsActiveTrueWithSubFilter(
         @Param("user") User user, 
         @Param("status") CampaignStatusType status, 


### PR DESCRIPTION
# Pull Request: 내 체험단 상태 조회 네이밍 변경

## 변경 사항 요약
- 내 체험단 상태 조회 - `subFilter` 네이밍 변경
- 북마크 API 내 user_id 추가

## 변경 이유
- 네이밍을 `open, close`로 했는데 명확하지 않아 수정했습니다.
- 클라이언트 요청으로 user_id 추가