### PR TITLE
fix: lazy loading error modified from fetchjoin

### DIFF
--- a/.github/workflows/drafter.yaml
+++ b/.github/workflows/drafter.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
 
 jobs:
   update_release_draft:
@@ -20,4 +19,4 @@ jobs:
         with:
           config-name: drafter-config.yaml
         env:
-          GITHUB_TOKEN: ${{ secrets.ODDONG_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/java/com/example/cherrydan/activity/repository/ActivityAlertRepository.java
+++ b/src/main/java/com/example/cherrydan/activity/repository/ActivityAlertRepository.java
@@ -22,9 +22,12 @@ public interface ActivityAlertRepository extends JpaRepository<ActivityAlert, Lo
 
 
     /**
-     * 당일 생성된 알림 미발송 활동 알림들 조회
+     * 당일 생성된 알림 미발송 활동 알림들 조회 (Campaign과 User를 Fetch Join으로 함께 조회)
      */
-    @Query("SELECT aa FROM ActivityAlert aa WHERE aa.alertStage = 0 AND aa.isVisibleToUser = true AND aa.alertDate = :alertDate")
+    @Query("SELECT aa FROM ActivityAlert aa " +
+           "JOIN FETCH aa.campaign c " +
+           "JOIN FETCH aa.user u " +
+           "WHERE aa.alertStage = 0 AND aa.isVisibleToUser = true AND aa.alertDate = :alertDate")
     List<ActivityAlert> findTodayUnnotifiedAlerts(@Param("alertDate") LocalDate alertDate);
 
     /**


### PR DESCRIPTION
- ActivityAlertRepository.findTodayUnnotifiedAlerts() 쿼리에 Fetch Join 추가
- JOIN FETCH aa.campaign c와 JOIN FETCH aa.user u로 연관 엔티티를 함께 조회
- Lazy Loading으로 인한 멀티스레드 환경에서의 Hibernate Session 충돌 문제 해결