### PR TITLE
feat: 캠페인 상태 배치 업데이트/삭제 기능을 구현했습니다

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
@@ -24,6 +24,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import com.example.cherrydan.common.exception.CampaignException;
 import com.example.cherrydan.common.exception.ErrorMessage;
+import com.example.cherrydan.campaign.dto.CampaignStatusBatchRequestDTO;
+import com.example.cherrydan.campaign.dto.CampaignStatusDeleteRequestDTO;
+
+import java.util.List;
 
 @Tag(name = "CampaignStatus", description = "내 체험단 상태 관리 및 팝업 API")
 @RestController
@@ -66,29 +70,27 @@ public class CampaignStatusController {
         @Valid @RequestBody CampaignStatusRequestDTO requestDTO,
         @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
-        requestDTO.setUserId(currentUser.getId());
-        CampaignStatusResponseDTO result = campaignStatusService.createOrRecoverStatus(requestDTO);
+        CampaignStatusResponseDTO result = campaignStatusService.createOrRecoverStatus(requestDTO, currentUser.getId());
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
-    @Operation(summary = "내 체험단 상태 변경", description = "is_active or status 변경")
+    @Operation(summary = "내 체험단 상태 변경", description = "배치로 여러 캠페인 상태 변경")
     @PatchMapping
-    public ResponseEntity<ApiResponse<CampaignStatusResponseDTO>> updateStatus(
-        @Valid @RequestBody CampaignStatusRequestDTO requestDTO,
+    public ResponseEntity<ApiResponse<List<CampaignStatusResponseDTO>>> updateStatus(
+        @RequestBody CampaignStatusBatchRequestDTO requestDTO,
         @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
-        requestDTO.setUserId(currentUser.getId());
-        CampaignStatusResponseDTO result = campaignStatusService.updateStatus(requestDTO);
-        return ResponseEntity.ok(ApiResponse.success(result));
+        List<CampaignStatusResponseDTO> results = campaignStatusService.updateStatusBatch(requestDTO, currentUser.getId());
+        return ResponseEntity.ok(ApiResponse.success(results));
     }
 
-    @Operation(summary = "내 체험단 상태 삭제", description = "campaignId만 받아서 삭제")
+    @Operation(summary = "내 체험단 상태 삭제", description = "campaignIds 리스트로 일괄 삭제")
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> deleteStatus(
-        @Valid @RequestBody DeleteRequest request,
+        @Valid @RequestBody CampaignStatusDeleteRequestDTO request,
         @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
-        campaignStatusService.deleteStatus(request.getCampaignId(), currentUser.getId());
+        campaignStatusService.deleteStatusBatch(request, currentUser.getId());
         return ResponseEntity.ok(ApiResponse.success());
     }
 
@@ -99,12 +101,5 @@ public class CampaignStatusController {
     ) {
         CampaignStatusPopupResponseDTO result = campaignStatusService.getPopupStatusByUser(currentUser.getId());
         return ResponseEntity.ok(ApiResponse.success(result));
-    }
-
-    public static class DeleteRequest {
-        @NotNull(message = "캠페인 ID는 필수입니다.")
-        private Long campaignId;
-
-        public Long getCampaignId() { return campaignId; }
     }
 } 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusBatchRequestDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusBatchRequestDTO.java
@@ -1,0 +1,24 @@
+package com.example.cherrydan.campaign.dto;
+
+import com.example.cherrydan.campaign.domain.CampaignStatusType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "캠페인 상태 배치 업데이트 요청")
+public class CampaignStatusBatchRequestDTO {
+    @Schema(description = "업데이트할 캠페인 ID 목록", example = "[1, 2, 3]", required = true)
+    private List<Long> campaignIds;
+    
+    @Schema(description = "변경할 캠페인 상태", example = "SELECTED", allowableValues = {"APPLY", "SELECTED", "NOT_SELECTED", "REVIEWING", "ENDED"})
+    private CampaignStatusType status;
+    
+    @Schema(description = "활성 상태 여부", example = "true")
+    private Boolean isActive;
+}

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusDeleteRequestDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusDeleteRequestDTO.java
@@ -1,0 +1,17 @@
+package com.example.cherrydan.campaign.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "캠페인 상태 배치 삭제 요청")
+public class CampaignStatusDeleteRequestDTO {
+    @Schema(description = "삭제할 캠페인 ID 목록", example = "[1, 2, 3]", required = true)
+    private List<Long> campaignIds;
+}

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
@@ -3,7 +3,6 @@ package com.example.cherrydan.campaign.dto;
 import com.example.cherrydan.campaign.domain.CampaignStatusType;
 import lombok.Getter;
 import lombok.Setter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
@@ -12,8 +11,6 @@ import jakarta.validation.constraints.NotNull;
 public class CampaignStatusRequestDTO {
     @NotNull(message = "캠페인 ID는 필수입니다.")
     private Long campaignId;
-    @JsonIgnore
-    private Long userId;
     @NotNull(message = "상태는 필수입니다.")
     @Schema(description = "캠페인 상태 타입 (APPLY: 지원한 공고, SELECTED: 선정 결과, NOT_SELECTED: 미선정 결과, REVIEWING: 리뷰 작성 중, ENDED: 작성 완료)", example = "APPLY", allowableValues = {"APPLY", "SELECTED", "NOT_SELECTED", "REVIEWING", "ENDED"})
     private CampaignStatusType status;

--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusService.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignStatusService.java
@@ -1,18 +1,16 @@
 package com.example.cherrydan.campaign.service;
 
-import com.example.cherrydan.campaign.dto.CampaignStatusRequestDTO;
-import com.example.cherrydan.campaign.dto.CampaignStatusResponseDTO;
-import com.example.cherrydan.campaign.dto.CampaignStatusListResponseDTO;
-import com.example.cherrydan.campaign.dto.CampaignStatusPopupResponseDTO;
+import com.example.cherrydan.campaign.dto.*;
+
 import com.example.cherrydan.campaign.domain.CampaignStatusType;
 import com.example.cherrydan.common.response.PageListResponseDTO;
-import com.example.cherrydan.campaign.dto.CampaignStatusCountResponseDTO;
 import org.springframework.data.domain.Pageable;
+import java.util.List;
 
 public interface CampaignStatusService {
-    CampaignStatusResponseDTO createOrRecoverStatus(CampaignStatusRequestDTO requestDTO);
-    CampaignStatusResponseDTO updateStatus(CampaignStatusRequestDTO requestDTO);
-    void deleteStatus(Long campaignId, Long userId);
+    CampaignStatusResponseDTO createOrRecoverStatus(CampaignStatusRequestDTO requestDTO, Long userId);
+    List<CampaignStatusResponseDTO> updateStatusBatch(CampaignStatusBatchRequestDTO requestDTO, Long userId);
+    void deleteStatusBatch(CampaignStatusDeleteRequestDTO requestDTO, Long userId);
     CampaignStatusPopupResponseDTO getPopupStatusByUser(Long userId);
     PageListResponseDTO<CampaignStatusResponseDTO> getStatusesByType(Long userId, CampaignStatusType statusType, Pageable pageable);
     CampaignStatusCountResponseDTO getStatusCounts(Long userId);

--- a/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/cherrydan/common/exception/ErrorMessage.java
@@ -32,7 +32,7 @@ public enum ErrorMessage {
     OAUTH_AUTHENTICATION_FAILED(UNAUTHORIZED, "OAuth 인증에 실패했습니다."),
     OAUTH_EMAIL_NOT_FOUND(UNAUTHORIZED, "OAuth2 제공자로부터 이메일을 찾을 수 없습니다."),
     OAUTH_USER_DELETED(UNAUTHORIZED, "탈퇴한 계정입니다. 계정 복구를 원하시면 고객센터에 문의해 주세요."),
-    OAUTH_PROVIDER_CONFLICT(CONFLICT, "이미 다른 소셜 계정으로 가입된 이메일입니다."),
+    OAUTH_PROVIDER_CONFLICT(UNAUTHORIZED, "이미 다른 소셜 계정으로 가입된 이메일입니다."),
     
     // Apple 관련 에러
     APPLE_IDENTITY_TOKEN_INVALID(UNAUTHORIZED, "Apple Identity Token이 유효하지 않습니다."),

--- a/src/main/java/com/example/cherrydan/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/cherrydan/common/exception/GlobalExceptionHandler.java
@@ -233,9 +233,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(OAuth2AuthenticationProcessingException.class)
     public ResponseEntity<ApiResponse<Void>> handleOAuth2AuthenticationProcessingException(OAuth2AuthenticationProcessingException ex) {
         ErrorMessage errorMessage = ex.getErrorMessage();
-        logger.error("OAuth2AuthenticationProcessingException: {}", errorMessage.getMessage());
-        return ResponseEntity.status(errorMessage.getHttpStatus())
-                .body(ApiResponse.error(errorMessage.getHttpStatus().value(), errorMessage.getMessage()));
+        String message = ex.getMessage();
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+        
+        if (errorMessage != null) {
+            status = errorMessage.getHttpStatus();
+            message = errorMessage.getMessage();
+        }
+        
+        logger.error("OAuth2AuthenticationProcessingException: {}", message);
+        return ResponseEntity.status(status)
+                .body(ApiResponse.error(status.value(), message));
     }
     
     /**

--- a/src/main/java/com/example/cherrydan/oauth/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/cherrydan/oauth/security/oauth2/CustomOAuth2UserService.java
@@ -179,7 +179,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             if (existingUser.getProvider() != null && !existingUser.getProvider().equals(provider)) {
                 throw new OAuth2AuthenticationProcessingException(
                         String.format("이미 %s 계정으로 가입되어 있습니다. %s 계정으로 로그인해 주세요.", 
-                        existingUser.getProvider(), existingUser.getProvider())
+                        existingUser.getProvider(), existingUser.getEmail())
                 );
             }
             

--- a/src/main/java/com/example/cherrydan/oauth/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/cherrydan/oauth/security/oauth2/CustomOAuth2UserService.java
@@ -177,7 +177,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             
             // 같은 제공자가 아니면 오류 발생
             if (existingUser.getProvider() != null && !existingUser.getProvider().equals(provider)) {
-                throw new OAuth2AuthenticationProcessingException(ErrorMessage.OAUTH_PROVIDER_CONFLICT);
+                throw new OAuth2AuthenticationProcessingException(
+                        String.format("이미 %s 계정으로 가입되어 있습니다. %s 계정으로 로그인해 주세요.", 
+                        existingUser.getProvider(), existingUser.getProvider())
+                );
             }
             
             // 정보 업데이트 후 반환

--- a/src/main/java/com/example/cherrydan/oauth/security/oauth2/exception/OAuth2AuthenticationProcessingException.java
+++ b/src/main/java/com/example/cherrydan/oauth/security/oauth2/exception/OAuth2AuthenticationProcessingException.java
@@ -11,6 +11,11 @@ public class OAuth2AuthenticationProcessingException extends AuthenticationExcep
         this.errorMessage = errorMessage;
     }
 
+    public OAuth2AuthenticationProcessingException(String message) {
+        super(message);
+        this.errorMessage = null;
+    }
+
     public ErrorMessage getErrorMessage() {
         return errorMessage;
     }


### PR DESCRIPTION
- CampaignStatusBatchRequestDTO: 배치 업데이트용 DTO 추가
- CampaignStatusDeleteRequestDTO: 배치 삭제용 DTO 추가
- CampaignStatusController: 배치 처리 API로 변경
- CampaignStatusService: 배치 처리 메서드 추가
- CampaignStatusRequestDTO: userId 필드 제거하고 컨트롤러에서 직접 전달
