### PR TITLE
refactor: 쿼리 최적화

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
+++ b/src/main/java/com/example/cherrydan/campaign/service/CampaignServiceImpl.java
@@ -158,7 +158,6 @@ public class CampaignServiceImpl implements CampaignService {
         );
         
         long totalElements = campaignRepository.countByKeywordAndCreatedDate(fullTextKeyword, date);
-        
         // N+1 문제 해결: 벌크 조회로 북마크 여부 확인
         List<Long> campaignIds = campaigns.stream()
             .map(Campaign::getId)


### PR DESCRIPTION
### 변경 내용
- CampaignRepository의 findByKeywordFullText 쿼리 최적화
- countByKeywordAndCreatedDate 쿼리 최적화  

## 기존 쿼리  (Original)
``` sql
SELECT * FROM campaigns 
WHERE MATCH(title) AGAINST(:keyword IN BOOLEAN MODE)
AND is_active = 1 
AND DATE(created_at) = DATE(:date - INTERVAL 1 DAY)
ORDER BY created_at DESC
LIMIT :offset, :limit
```

## 대안 1쿼리 (Simple)
``` sql
SELECT * FROM campaigns
WHERE created_at >= DATE(:date - INTERVAL 1 DAY) AND created_at < DATE(:date)
AND is_active = 1
AND MATCH(title) AGAINST(:keyword IN BOOLEAN MODE)
ORDER BY id DESC
LIMIT :offset, :limit
```

## 최종 수정 쿼리 (Optimized)
``` sql
SELECT
	c.*
FROM (
	SELECT
		id
	FROM 
		campaigns FORCE INDEX(campaigns_created_at_is_active_IDX)
	WHERE 
		created_at >= DATE(:date - INTERVAL 1 DAY) AND created_at < DATE(:date) AND is_active = 1) 
	AS filtered
STRAIGHT_JOIN campaigns AS c ON c.id = filtered.id
WHERE 
	MATCH(c.title) AGAINST(:keyword IN BOOLEAN MODE)
	ORDER BY c.id DESC
LIMIT :offset, :limit
```
> 복합 인덱스를 통해 created_at, is_active 필터링을 거친 뒤, 풀텍스트 인덱스를 거치게 수정하였습니다.


## 실행 계획
```
-> Limit: 20 row(s)  (actual time=49.1..49.1 rows=20 loops=1)
    -> Sort: c.id DESC, limit input to 20 row(s) per chunk  (actual time=49.1..49.1 rows=20 loops=1)
        -> Stream results  (cost=3263 rows=657) (actual time=23.4..46.5 rows=987 loops=1)
            -> Nested loop inner join  (cost=3263 rows=657) (actual time=23.4..44.5 rows=987 loops=1)
                -> Filter: ((campaigns.is_active = 1) and (campaigns.created_at >= <cache>(cast(('2025-09-02' - interval 1 day) as date))) and (campaigns.created_at < <cache>(cast('2025-09-02' as date))))  (cost=1193 rows=5912) (actual time=20.5..24.5 rows=5706 loops=1)
                    -> Covering index range scan on campaigns using campaigns_created_at_is_active_IDX over ('2025-09-01 00:00:00' <= created_at <= '2025-09-02 00:00:00' AND 1 <= is_active)  (cost=1193 rows=5912) (actual time=18.9..21.2 rows=5912 loops=1)
                -> Filter: (match c.title against ('+서울*' in boolean mode))  (cost=0.25 rows=0.111) (actual time=0.00336..0.00338 rows=0.173 loops=5706)
                    -> Single-row index lookup on c using PRIMARY (id=campaigns.id)  (cost=0.25 rows=1) (actual time=0.00278..0.00281 rows=1 loops=5706)
```

## locust 부하 테스트 (user = 30, ramp_up = 1)
<img width="1419" height="348" alt="스크린샷 2025-09-02 오후 12 49 53" src="https://github.com/user-attachments/assets/2bd1715b-1a76-46eb-bccb-653337db1892" />
