### PR TITLE
docs: ActivityAlertResponseDTO에 Swagger nullable 명시했습니다.

### DIFF
--- a/src/main/java/com/example/cherrydan/activity/dto/ActivityAlertResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/activity/dto/ActivityAlertResponseDTO.java
@@ -15,40 +15,41 @@ import java.time.LocalDate;
 @Builder
 @Schema(description = "활동 알림 응답 DTO")
 public class ActivityAlertResponseDTO {
-    
-    @Schema(description = "알림 ID", example = "1")
+
+    @Schema(description = "알림 ID", example = "1", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Long id;
-    
-    @Schema(description = "캠페인 ID", example = "123")
+
+    @Schema(description = "캠페인 ID", example = "123", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Long campaignId;
-    
-    @Schema(description = "캠페인 제목", example = "[양주] 리치마트 양주점_피드&릴스")
+
+    @Schema(description = "알림 타이틀", example = "방문 알림", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
+    private String alertTitle;
+
+    @Schema(description = "dDay 알림 타이틀", example = "D-3", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
+    private String dayTitle;
+
+    @Schema(description = "캠페인 타이틀", example = "[양주] 리치마트 양주점_피드&릴스", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignTitle;
-    
-    @Schema(description = "신청 마감일", example = "2024-07-24")
-    private LocalDate applyEndDate;
-    
-    @Schema(description = "알림 날짜", example = "2024-07-21")
+
+    @Schema(description = "며칠 남았는 지", example = "피드&릴스 방문일이 3일 남았습니다.", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
+    private String alertBody;
+
+    @Schema(description = "알림 날짜", example = "2024-07-21", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDate alertDate;
-    
-    @Schema(description = "읽음 여부", example = "false")
+
+    @Schema(description = "읽음 여부", example = "false", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean isRead;
-    
-    @Schema(description = "D-day (마감까지 남은 일수)", example = "3")
-    private Integer dDay;
 
     public static ActivityAlertResponseDTO fromEntity(ActivityAlert activityAlert) {
-        final int FIXED_D_DAY = 3;
-        LocalDate applyEndDate = activityAlert.getCampaign().getApplyEnd();
-        
         return ActivityAlertResponseDTO.builder()
                 .id(activityAlert.getId())
                 .campaignId(activityAlert.getCampaign().getId())
+                .alertTitle(activityAlert.getAlertType().getTitle())
+                .dayTitle(activityAlert.getAlertType().getDDayLabel())
                 .campaignTitle(activityAlert.getCampaign().getTitle())
-                .applyEndDate(applyEndDate)
+                .alertBody(activityAlert.getAlertType().getMessageTemplate())
                 .alertDate(activityAlert.getAlertDate())
                 .isRead(activityAlert.getIsRead())
-                .dDay(FIXED_D_DAY)
                 .build();
     }
 }

--- a/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/CampaignStatusController.java
@@ -2,7 +2,6 @@ package com.example.cherrydan.campaign.controller;
 
 import com.example.cherrydan.campaign.dto.CampaignStatusRequestDTO;
 import com.example.cherrydan.campaign.dto.CampaignStatusResponseDTO;
-import com.example.cherrydan.campaign.dto.CampaignStatusListResponseDTO;
 import com.example.cherrydan.campaign.dto.CampaignStatusCountResponseDTO;
 import com.example.cherrydan.campaign.domain.CampaignStatusType;
 import com.example.cherrydan.common.response.EmptyResponse;

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignResponseDTO.java
@@ -17,19 +17,35 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Getter
 @Builder
 public class CampaignResponseDTO {
+    @Schema(description = "캠페인 ID", example = "1", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Long id;
+
+    @Schema(description = "캠페인 제목", example = "[양주] 리치마트 양주점_피드&릴스", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String title;
+
+    @Schema(description = "캠페인 상세 URL", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String detailUrl;
+
+    @Schema(description = "혜택 정보", example = "5만원 상당 체험권 제공", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String benefit;
+
+    @Schema(description = "마감 상태 메시지", example = "신청 마감 3일 전", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String reviewerAnnouncementStatus;
+
+    @Schema(description = "신청자 수", example = "150", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Integer applicantCount;
+
+    @Schema(description = "모집 인원", example = "10", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Integer recruitCount;
 
     @Deprecated
-    @Schema(description = "플랫폼 이름(deprecated(v1.0.2까지))", deprecated = true)
+    @Schema(description = "플랫폼 이름(deprecated)", deprecated = true, nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty("campaignSite")
     private String sourceSite;
+
+    @Schema(description = "캠페인 이미지 URL", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String imageUrl;
+
     @JsonIgnore private Boolean youtube;
     @JsonIgnore private Boolean shorts;
     @JsonIgnore private Boolean insta;
@@ -39,16 +55,27 @@ public class CampaignResponseDTO {
     @JsonIgnore private Boolean tiktok;
     @JsonIgnore private Boolean thread;
     @JsonIgnore private Boolean etc;
+
+    @Schema(description = "북마크 여부", example = "false", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean isBookmarked;
 
     @Deprecated
-    @Schema(description = "기존 플랫폼 이미지 URL(deprecated(v1.0.2까지))", deprecated = true)
+    @Schema(description = "기존 플랫폼 이미지 URL(deprecated)", deprecated = true, nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String campaignPlatformImageUrl;
-    
+
+    @Schema(description = "캠페인 플랫폼 이미지 URL", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignSiteUrl;
+
+    @Schema(description = "캠페인 플랫폼 한글명", example = "레뷰", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignSiteKr;
+
+    @Schema(description = "캠페인 플랫폼 영문 코드", example = "revu", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignSiteEn;
+
+    @Schema(description = "캠페인 타입", example = "DELIVERY", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private CampaignType campaignType;
+
+    @Schema(description = "경쟁률", example = "15.0", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Float competitionRate;
 
     @JsonProperty("snsPlatforms")

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignSiteResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignSiteResponseDTO.java
@@ -15,18 +15,23 @@ import com.example.cherrydan.common.util.CloudfrontUtil;
 public class CampaignSiteResponseDTO {
 
     @Deprecated
-    @Schema(description = "기존 플랫폼 한글명(deprecated(v1.0.2까지))", deprecated = true)
+    @Schema(description = "기존 플랫폼 한글명(deprecated)", deprecated = true, nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String siteNameKr;
 
     @Deprecated
-    @Schema(description = "기존 플랫폼 영문명(deprecated(v1.0.2까지))", deprecated = true)
+    @Schema(description = "기존 플랫폼 영문명(deprecated)", deprecated = true, nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String siteNameEn;
 
     @Deprecated
-    @Schema(description = "기존 플랫폼 CDN URL(deprecated(v1.0.2까지))", deprecated = true)
+    @Schema(description = "기존 플랫폼 CDN URL(deprecated)", deprecated = true, nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String cdnUrl;
 
+    @Schema(description = "캠페인 플랫폼 이미지 URL", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignSiteUrl;
+
+    @Schema(description = "캠페인 플랫폼 한글명", example = "레뷰", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignSiteKr;
+
+    @Schema(description = "캠페인 플랫폼 영문 코드", example = "revu", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignSiteEn;
 } 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusBatchRequestDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusBatchRequestDTO.java
@@ -16,12 +16,12 @@ import java.util.List;
 public class CampaignStatusBatchRequestDTO {
 
     @NotEmpty(message = "캠페인 ID 목록은 필수입니다.")
-    @Schema(description = "업데이트할 캠페인 ID 목록", example = "[1, 2, 3]", required = true)
+    @Schema(description = "업데이트할 캠페인 ID 목록", example = "[1, 2, 3]", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private List<Long> campaignIds;
-    
-    @Schema(description = "변경할 캠페인 상태", example = "SELECTED", allowableValues = {"APPLY", "SELECTED", "NOT_SELECTED", "REVIEWING", "ENDED"})
+
+    @Schema(description = "변경할 캠페인 상태", example = "SELECTED", allowableValues = {"APPLY", "SELECTED", "NOT_SELECTED", "REVIEWING", "ENDED"}, nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private CampaignStatusType status;
-    
-    @Schema(description = "활성 상태 여부", example = "true")
+
+    @Schema(description = "활성 상태 여부", example = "true", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Boolean isActive;
 }

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusPopupByTypeResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusPopupByTypeResponseDTO.java
@@ -10,12 +10,12 @@ import java.util.List;
 @Builder
 @Schema(description = "특정 상태의 내 체험단 팝업용 응답 DTO")
 public class CampaignStatusPopupByTypeResponseDTO {
-    @Schema(description = "상태 타입", example = "APPLY")
+    @Schema(description = "상태 타입", example = "APPLY", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private CampaignStatusType statusType;
-    
-    @Schema(description = "총 개수", example = "4")
+
+    @Schema(description = "총 개수", example = "4", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private long totalCount;
-    
-    @Schema(description = "팝업 아이템 리스트 (최대 4개)")
+
+    @Schema(description = "팝업 아이템 리스트 (최대 4개)", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private List<CampaignStatusPopupItemDTO> items;
 }

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusRequestDTO.java
@@ -10,9 +10,13 @@ import jakarta.validation.constraints.NotNull;
 @Setter
 public class CampaignStatusRequestDTO {
     @NotNull(message = "캠페인 ID는 필수입니다.")
+    @Schema(description = "캠페인 ID", example = "123", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Long campaignId;
+
     @NotNull(message = "상태는 필수입니다.")
-    @Schema(description = "캠페인 상태 타입 (APPLY: 지원한 공고, SELECTED: 선정 결과, NOT_SELECTED: 미선정 결과, REVIEWING: 리뷰 작성 중, ENDED: 작성 완료)", example = "APPLY", allowableValues = {"APPLY", "SELECTED", "NOT_SELECTED", "REVIEWING", "ENDED"})
+    @Schema(description = "캠페인 상태 타입 (APPLY: 지원한 공고, SELECTED: 선정 결과, NOT_SELECTED: 미선정 결과, REVIEWING: 리뷰 작성 중, ENDED: 작성 완료)", example = "APPLY", allowableValues = {"APPLY", "SELECTED", "NOT_SELECTED", "REVIEWING", "ENDED"}, nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private CampaignStatusType status;
+
+    @Schema(description = "활성 상태 여부", example = "true", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Boolean isActive;
 } 

--- a/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/campaign/dto/CampaignStatusResponseDTO.java
@@ -18,21 +18,48 @@ import lombok.Getter;
 @Builder
 @Schema(description = "캠페인 상태 응답 DTO")
 public class CampaignStatusResponseDTO {
+    @Schema(description = "캠페인 상태 ID", example = "1", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Long id;
+
+    @Schema(description = "캠페인 ID", example = "123", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Long campaignId;
+
+    @Schema(description = "사용자 ID", example = "456", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Long userId;
+
+    @Schema(description = "마감 상태 메시지", example = "발표 3일 전", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String reviewerAnnouncementStatus;
-    @Schema(description = "상태 보조 라벨 (예: APPLY의 경우 waiting/completed)")
+
+    @Schema(description = "상태 보조 라벨 (예: APPLY의 경우 waiting/completed)", example = "waiting", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String subStatusLabel;
+
+    @Schema(description = "캠페인 제목", example = "[양주] 리치마트 양주점_피드&릴스", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignTitle;
+
+    @Schema(description = "혜택 정보", example = "5만원 상당 체험권 제공", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String benefit;
+
+    @Schema(description = "캠페인 상세 URL", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignDetailUrl;
+
+    @Schema(description = "캠페인 이미지 URL", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignImageUrl;
+
+    @Schema(description = "캠페인 플랫폼 이미지 URL", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String campaignPlatformImageUrl;
+
+    @Schema(description = "신청자 수", example = "150", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private int applicantCount;
+
+    @Schema(description = "모집 인원", example = "10", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private int recruitCount;
+
+    @Schema(description = "SNS 플랫폼 목록", example = "[\"인스타그램\", \"블로그\"]", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private List<String> snsPlatforms;
+
+    @Schema(description = "캠페인 사이트명", example = "레뷰", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String campaignSite;
+
     @JsonIgnore private LocalDate reviewerAnnouncement;
     @JsonIgnore private LocalDate contentSubmissionEnd;
     @JsonIgnore private LocalDate resultAnnouncement;

--- a/src/main/java/com/example/cherrydan/user/dto/KeywordCampaignAlertResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/user/dto/KeywordCampaignAlertResponseDTO.java
@@ -15,20 +15,20 @@ import java.time.LocalDate;
 @Builder
 @Schema(description = "키워드 캠페인 알림 응답 DTO")
 public class KeywordCampaignAlertResponseDTO {
-    
-    @Schema(description = "알림 ID", example = "1")
+
+    @Schema(description = "알림 ID", example = "1", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Long id;
-    
-    @Schema(description = "매칭된 키워드", example = "뷰티")
+
+    @Schema(description = "매칭된 키워드", example = "뷰티", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String keyword;
-    
-    @Schema(description = "읽음 상태", example = "false")
+
+    @Schema(description = "읽음 상태", example = "false", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean isRead;
 
-    @Schema(description = "매칭된 캠페인 수", example = "10")
+    @Schema(description = "매칭된 캠페인 수", example = "10", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer campaignCount;
 
-    @Schema(description = "알림 날짜", example = "2024-07-21")
+    @Schema(description = "알림 날짜", example = "2024-07-21", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDate alertDate;
     
     /**

--- a/src/main/java/com/example/cherrydan/user/dto/UserKeywordResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/user/dto/UserKeywordResponseDTO.java
@@ -1,6 +1,7 @@
 package com.example.cherrydan.user.dto;
 
 import com.example.cherrydan.user.domain.UserKeyword;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,8 +11,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "사용자 키워드 응답")
 public class UserKeywordResponseDTO {
+    @Schema(description = "키워드 ID", example = "1", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private Long id;
+
+    @Schema(description = "키워드", example = "뷰티", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
     private String keyword;
 
     public static UserKeywordResponseDTO fromKeyword(UserKeyword keyword) {


### PR DESCRIPTION
  ### 변경 내용
  - Response DTO 9개 파일에 Swagger `nullable`과 `requiredMode` 속성 명시
    - ActivityAlertResponseDTO, CampaignResponseDTO, CampaignStatusResponseDTO, CampaignSiteResponseDTO, KeywordCampaignAlertResponseDTO, UserKeywordResponseDTO 등
  - Request DTO 5개 파일에 Swagger `nullable`과 `requiredMode` 속성 명시
    - CampaignResponseDTO, CampaignSiteResponseDTO, CampaignSiteServiceImpl
  - CampaignStatusController의 미사용 import 제거

  ### 변경 이유
  - 클라이언트가 API 응답에서 어떤 필드가 null일 수 있는지 명확히 알 수 없어 모든 필드에 방어적으로 null 체크를 수행하고 있었음
  - Swagger 문서에서 nullable/required 필드를 명시적으로 표시하여 클라이언트 개발자가 API 스펙을 정확히 이해하고 불필요한 방어 코드를 줄일 수 있도록 개선
  - API 문서의 명확성과 가독성 향상



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Campaign responses now include richer details: IDs, titles, URLs, benefits, counts, images, bookmark status, platform info (KR/EN/URL), type, and competition rate.
  - Campaign status responses add IDs, user, labels, counts, platform/site info, and SNS platforms.
  - Activity alerts now provide alertTitle, dayTitle, and alertBody; legacy applyEndDate/D-Day removed.
  - Status requests support isActive.

- Documentation
  - API schemas updated with clearer required/nullable metadata and examples.
  - Legacy platform fields marked deprecated; new platform fields highlighted in docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->