### PR TITLE
feat: 읽지 않은 활동 알림과 키워드 알림의  개수를 반환하는 API를 만들었습니다.

### DIFF
--- a/src/main/java/com/example/cherrydan/activity/controller/ActivityController.java
+++ b/src/main/java/com/example/cherrydan/activity/controller/ActivityController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,25 +37,25 @@ public class ActivityController {
         description = """
             사용자의 북마크 기반 활동 알림 목록을 조회합니다.
             북마크한 캠페인의 신청 마감이 3일 남았을 때 생성되는 알림들입니다.
-            
+
             **쿼리 파라미터 예시:**
             - ?page=0&size=20&sort=alertDate,desc
             - ?page=1&size=10&sort=alertDate,asc
-            
+
             **정렬 가능한 필드:**
             - alertDate: 알림 생성 날짜 (기본값, DESC)
-            
+
             **주의:** 이는 Request Body가 아닌 **Query Parameter**입니다.
             """
     )
     @GetMapping("/bookmark-alerts")
-    public ApiResponse<PageListResponseDTO<ActivityAlertResponseDTO>> getBookmarkActivityAlerts(
+    public ResponseEntity<ApiResponse<PageListResponseDTO<ActivityAlertResponseDTO>>> getBookmarkActivityAlerts(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @PageableDefault(size = 20, sort = "alertDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<ActivityAlertResponseDTO> alerts = activityAlertService.getUserActivityAlerts(currentUser.getId(), pageable);
         PageListResponseDTO<ActivityAlertResponseDTO> response = PageListResponseDTO.from(alerts);
-        return ApiResponse.success("북마크 활동 알림 목록 조회 성공", response);
+        return ResponseEntity.ok(ApiResponse.success("북마크 활동 알림 목록 조회 성공", response));
     }
 
     @Operation(
@@ -62,11 +63,11 @@ public class ActivityController {
         description = "사용자의 북마크 기반 활동 알림 개수를 조회합니다."
     )
     @GetMapping("/bookmark-alerts/count")
-    public ApiResponse<Long> getBookmarkActivityAlertsCount(
+    public ResponseEntity<ApiResponse<Long>> getBookmarkActivityAlertsCount(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
         Long alertsCount = activityAlertService.getUserActivityAlertsCount(currentUser.getId());
-        return ApiResponse.success("북마크 활동 알림 개수 조회 성공", alertsCount);
+        return ResponseEntity.ok(ApiResponse.success("북마크 활동 알림 개수 조회 성공", alertsCount));
     }
 
     @Operation(
@@ -74,12 +75,12 @@ public class ActivityController {
         description = "선택한 북마크 기반 활동 알림들을 삭제합니다. 본인의 알림이 아닌 경우 403 에러를 반환합니다."
     )
     @DeleteMapping("/bookmark-alerts")
-    public ApiResponse<Void> deleteBookmarkActivityAlerts(
+    public ResponseEntity<ApiResponse<Void>> deleteBookmarkActivityAlerts(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestBody AlertIdsRequestDTO request
     ) {
         activityAlertService.deleteActivityAlert(currentUser.getId(), request.getAlertIds());
-        return ApiResponse.success("북마크 활동 알림 삭제 성공", null);
+        return ResponseEntity.ok(ApiResponse.success("북마크 활동 알림 삭제 성공", null));
     }
 
     @Operation(
@@ -87,11 +88,11 @@ public class ActivityController {
         description = "선택한 북마크 기반 활동 알림들을 읽음 상태로 변경합니다. 본인의 알림이 아닌 경우 403 에러를 반환합니다."
     )
     @PatchMapping("/bookmark-alerts/read")
-    public ApiResponse<Void> markBookmarkActivityAlertsAsRead(
+    public ResponseEntity<ApiResponse<Void>> markBookmarkActivityAlertsAsRead(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestBody AlertIdsRequestDTO request
     ) {
         activityAlertService.markActivityAlertsAsRead(currentUser.getId(), request.getAlertIds());
-        return ApiResponse.success("북마크 활동 알림 읽음 처리 성공", null);
+        return ResponseEntity.ok(ApiResponse.success("북마크 활동 알림 읽음 처리 성공", null));
     }
 } 

--- a/src/main/java/com/example/cherrydan/activity/controller/AlertController.java
+++ b/src/main/java/com/example/cherrydan/activity/controller/AlertController.java
@@ -1,0 +1,36 @@
+package com.example.cherrydan.activity.controller;
+
+import com.example.cherrydan.activity.dto.UnreadAlertCountResponseDTO;
+import com.example.cherrydan.activity.service.AlertService;
+import com.example.cherrydan.common.response.ApiResponse;
+import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Alert", description = "알림 관련 API")
+@RestController
+@RequestMapping("/api/alerts")
+@RequiredArgsConstructor
+public class AlertController {
+
+    private final AlertService alertService;
+
+    @Operation(
+        summary = "미읽은 알림 개수 조회",
+        description = "사용자의 미읽은 알림 개수를 조회합니다. 활동 알림과 키워드 알림의 개수를 각각 제공하며, 전체 개수도 함께 반환합니다."
+    )
+    @GetMapping("/unread-count")
+    public ResponseEntity<ApiResponse<UnreadAlertCountResponseDTO>> getUnreadAlertCount(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
+    ) {
+        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/example/cherrydan/activity/controller/AlertController.java
+++ b/src/main/java/com/example/cherrydan/activity/controller/AlertController.java
@@ -30,7 +30,7 @@ public class AlertController {
     public ResponseEntity<ApiResponse<UnreadAlertCountResponseDTO>> getUnreadAlertCount(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
     ) {
-        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(user.getUserId());
+        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(user.getId());
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/example/cherrydan/activity/domain/ActivityAlert.java
+++ b/src/main/java/com/example/cherrydan/activity/domain/ActivityAlert.java
@@ -61,11 +61,15 @@ public class ActivityAlert extends BaseTimeEntity {
     public void markAsRead() {
         this.isRead = true;
     }
-    
+
+    public void hide() {
+        this.isVisibleToUser = false;
+    }
+
     public String getNotificationTitle() {
         return alertType.getTitle();
     }
-    
+
     public String getNotificationBody() {
         return alertType.getBodyTemplate(campaign.getTitle());
     }

--- a/src/main/java/com/example/cherrydan/activity/dto/UnreadAlertCountResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/activity/dto/UnreadAlertCountResponseDTO.java
@@ -1,0 +1,21 @@
+package com.example.cherrydan.activity.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UnreadAlertCountResponseDTO {
+
+    @Schema(description = "총 미읽은 알림 개수", example = "15", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
+    private Integer totalCount;
+
+    @Schema(description = "활동 알림 미읽은 개수", example = "8", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
+    private Integer activityAlertCount;
+
+    @Schema(description = "키워드 알림 미읽은 개수", example = "7", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
+    private Integer keywordAlertCount;
+}

--- a/src/main/java/com/example/cherrydan/activity/dto/UnreadAlertCountResponseDTO.java
+++ b/src/main/java/com/example/cherrydan/activity/dto/UnreadAlertCountResponseDTO.java
@@ -11,11 +11,11 @@ import lombok.Getter;
 public class UnreadAlertCountResponseDTO {
 
     @Schema(description = "총 미읽은 알림 개수", example = "15", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
-    private Integer totalCount;
+    private Long totalCount;
 
     @Schema(description = "활동 알림 미읽은 개수", example = "8", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
-    private Integer activityAlertCount;
+    private Long activityAlertCount;
 
     @Schema(description = "키워드 알림 미읽은 개수", example = "7", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
-    private Integer keywordAlertCount;
+    private Long keywordAlertCount;
 }

--- a/src/main/java/com/example/cherrydan/activity/repository/ActivityAlertRepository.java
+++ b/src/main/java/com/example/cherrydan/activity/repository/ActivityAlertRepository.java
@@ -52,4 +52,10 @@ public interface ActivityAlertRepository extends JpaRepository<ActivityAlert, Lo
      */
     @Query("SELECT COUNT(aa) > 0 FROM ActivityAlert aa WHERE aa.user.id = :userId AND aa.campaign.id = :campaignId AND aa.isVisibleToUser = true")
     boolean existsByUserIdAndCampaignId(@Param("userId") Long userId, @Param("campaignId") Long campaignId);
+
+    /**
+     * 사용자의 미읽은 활동 알림 개수 조회
+     */
+    @Query("SELECT COUNT(aa) FROM ActivityAlert aa WHERE aa.user.id = :userId AND aa.isRead = false AND aa.isVisibleToUser = true")
+    long countUnreadByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/cherrydan/activity/repository/ActivityAlertRepository.java
+++ b/src/main/java/com/example/cherrydan/activity/repository/ActivityAlertRepository.java
@@ -57,5 +57,5 @@ public interface ActivityAlertRepository extends JpaRepository<ActivityAlert, Lo
      * 사용자의 미읽은 활동 알림 개수 조회
      */
     @Query("SELECT COUNT(aa) FROM ActivityAlert aa WHERE aa.user.id = :userId AND aa.isRead = false AND aa.isVisibleToUser = true")
-    long countUnreadByUserId(@Param("userId") Long userId);
+    Long countUnreadByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/cherrydan/activity/service/ActivityAlertService.java
+++ b/src/main/java/com/example/cherrydan/activity/service/ActivityAlertService.java
@@ -163,21 +163,22 @@ public class ActivityAlertService {
 
 
     /**
-     * 활동 알림 삭제 (배열)
+     * 활동 알림 삭제 (소프트 삭제)
      */
     @Transactional
     public void deleteActivityAlert(Long userId, List<Long> alertIds) {
         List<ActivityAlert> alerts = activityAlertRepository.findAllById(alertIds);
-        
+
         // 모든 알림이 해당 사용자의 것인지 확인
         for (ActivityAlert alert : alerts) {
             if (!alert.getUser().getId().equals(userId)) {
                 throw new UserException(ErrorMessage.ACTIVITY_ALERT_ACCESS_DENIED);
             }
+            alert.hide();
         }
-        
-        activityAlertRepository.deleteAll(alerts);
-        log.info("활동 알림 삭제 완료: userId={}, count={}", userId, alertIds.size());
+
+        activityAlertRepository.saveAll(alerts);
+        log.info("활동 알림 숨김 처리 완료: userId={}, count={}", userId, alertIds.size());
     }
 
     /**

--- a/src/main/java/com/example/cherrydan/activity/service/AlertService.java
+++ b/src/main/java/com/example/cherrydan/activity/service/AlertService.java
@@ -1,0 +1,33 @@
+package com.example.cherrydan.activity.service;
+
+import com.example.cherrydan.activity.dto.UnreadAlertCountResponseDTO;
+import com.example.cherrydan.activity.repository.ActivityAlertRepository;
+import com.example.cherrydan.user.repository.KeywordCampaignAlertRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlertService {
+
+    private final ActivityAlertRepository activityAlertRepository;
+    private final KeywordCampaignAlertRepository keywordCampaignAlertRepository;
+
+    /**
+     * 사용자의 미읽은 알림 개수 조회
+     */
+    @Transactional(readOnly = true)
+    public UnreadAlertCountResponseDTO getUnreadAlertCount(Long userId) {
+        long activityCount = activityAlertRepository.countUnreadByUserId(userId);
+        long keywordCount = keywordCampaignAlertRepository.countUnreadByUserId(userId);
+
+        return UnreadAlertCountResponseDTO.builder()
+                .totalCount((int) (activityCount + keywordCount))
+                .activityAlertCount((int) activityCount)
+                .keywordAlertCount((int) keywordCount)
+                .build();
+    }
+}

--- a/src/main/java/com/example/cherrydan/activity/service/AlertService.java
+++ b/src/main/java/com/example/cherrydan/activity/service/AlertService.java
@@ -21,13 +21,13 @@ public class AlertService {
      */
     @Transactional(readOnly = true)
     public UnreadAlertCountResponseDTO getUnreadAlertCount(Long userId) {
-        long activityCount = activityAlertRepository.countUnreadByUserId(userId);
-        long keywordCount = keywordCampaignAlertRepository.countUnreadByUserId(userId);
+        Long activityCount = activityAlertRepository.countUnreadByUserId(userId);
+        Long keywordCount = keywordCampaignAlertRepository.countUnreadByUserId(userId);
 
         return UnreadAlertCountResponseDTO.builder()
-                .totalCount((int) (activityCount + keywordCount))
-                .activityAlertCount((int) activityCount)
-                .keywordAlertCount((int) keywordCount)
+                .totalCount(activityCount + keywordCount)
+                .activityAlertCount(activityCount)
+                .keywordAlertCount(keywordCount)
                 .build();
     }
 }

--- a/src/main/java/com/example/cherrydan/sns/controller/SnsController.java
+++ b/src/main/java/com/example/cherrydan/sns/controller/SnsController.java
@@ -34,32 +34,32 @@ public class SnsController {
 
     @Operation(summary = "OAuth 인증 URL 생성")
     @GetMapping("/oauth/{platform}/auth-url")
-    public ApiResponse<String> getAuthUrl(@PathVariable("platform") String platform) {
+    public ResponseEntity<ApiResponse<String>> getAuthUrl(@PathVariable("platform") String platform) {
         SnsPlatform snsPlatform = SnsPlatform.fromPlatformCode(platform);
         String authUrl = snsOAuthService.getAuthUrl(snsPlatform);
-        return ApiResponse.success(snsPlatform.getDisplayName() + " 인증 URL 생성 성공", authUrl);
+        return ResponseEntity.ok(ApiResponse.success(snsPlatform.getDisplayName() + " 인증 URL 생성 성공", authUrl));
     }
 
     @Operation(summary = "OAuth 콜백 처리")
     @GetMapping("/oauth/{platform}/callback")
-    public Mono<ApiResponse<SnsConnectionResponse>> handleOAuthCallback(
+    public Mono<ResponseEntity<ApiResponse<SnsConnectionResponse>>> handleOAuthCallback(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable("platform") String platform,
             @RequestParam("code") String code) {
         SnsPlatform snsPlatform = SnsPlatform.fromPlatformCode(platform);
         User user = userService.getUserById(userDetails.getId());
-        
+
         return snsOAuthService.connect(user, code, snsPlatform)
-                .map(response -> ApiResponse.success(snsPlatform.getDisplayName() + " 연동이 완료되었습니다.", response));
+                .map(response -> ResponseEntity.ok(ApiResponse.success(snsPlatform.getDisplayName() + " 연동이 완료되었습니다.", response)));
     }
 
     @Operation(summary = "사용자 SNS 연동 목록 조회")
     @GetMapping("/connections")
-    public ApiResponse<List<SnsConnectionResponse>> getConnections(
+    public ResponseEntity<ApiResponse<List<SnsConnectionResponse>>> getConnections(
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userService.getUserById(userDetails.getId());
         List<SnsConnectionResponse> response = snsOAuthService.getUserSnsConnections(user);
-        return ApiResponse.success("SNS 연동 목록 조회 성공", response);
+        return ResponseEntity.ok(ApiResponse.success("SNS 연동 목록 조회 성공", response));
     }
 
     @Operation(summary = "SNS 연동 해제")

--- a/src/main/java/com/example/cherrydan/user/controller/UserKeywordController.java
+++ b/src/main/java/com/example/cherrydan/user/controller/UserKeywordController.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,35 +44,35 @@ public class UserKeywordController {
         summary = "내 키워드 알림 목록 조회",
         description = """
             사용자의 키워드 알림 히스토리를 조회합니다.
-            
+
             **쿼리 파라미터 예시:**
             - ?page=0&size=20&sort=alertDate,desc
             - ?page=1&size=10&sort=alertDate,asc
-            
+
             **정렬 가능한 필드:**
             - alertDate: 알림 발송 날짜 (기본값, DESC)
-            
+
             **여러 정렬 조건 (쿼리 파라미터):**
             - ?sort=alertDate,desc&sort=id,asc (복수 정렬)
             - ?sort=alertDate,desc (단일 정렬, 기본값)
             - ?sort=alertDate,asc (오래된 순)
-            
+
             sort : 정렬 기준 (예: alertDate,desc) -> 선택사항
-            
+
             **주의:** 이는 Request Body가 아닌 **Query Parameter**입니다.
             """,
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @GetMapping("/alerts")
-    public ApiResponse<PageListResponseDTO<KeywordCampaignAlertResponseDTO>> getUserKeywordAlerts(
+    public ResponseEntity<ApiResponse<PageListResponseDTO<KeywordCampaignAlertResponseDTO>>> getUserKeywordAlerts(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @PageableDefault(size = 20, sort = "alertDate") Pageable pageable
     ) {
         Page<KeywordCampaignAlertResponseDTO> alerts = userKeywordService.getUserKeywordAlerts(currentUser.getId(), pageable);
         PageListResponseDTO<KeywordCampaignAlertResponseDTO> response = PageListResponseDTO.from(alerts);
-        return ApiResponse.success("키워드 알림 목록 조회 성공", response);
+        return ResponseEntity.ok(ApiResponse.success("키워드 알림 목록 조회 성공", response));
     }
-    
+
 
     @Operation(
         summary = "내 키워드 목록 조회",
@@ -79,13 +80,13 @@ public class UserKeywordController {
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @GetMapping("/me")
-    public ApiResponse<List<UserKeywordResponseDTO>> getMyKeywords(
+    public ResponseEntity<ApiResponse<List<UserKeywordResponseDTO>>> getMyKeywords(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
         if (currentUser == null) throw new AuthException(ErrorMessage.AUTH_UNAUTHORIZED);
         List<UserKeywordResponseDTO> keywords = userKeywordService.getKeywords(currentUser.getId())
             .stream().map(UserKeywordResponseDTO::fromKeyword).toList();
-        return ApiResponse.success("키워드 목록 조회 성공", keywords);
+        return ResponseEntity.ok(ApiResponse.success("키워드 목록 조회 성공", keywords));
     }
 
     @Operation(
@@ -94,13 +95,13 @@ public class UserKeywordController {
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @PostMapping("/me")
-    public ApiResponse<EmptyResponse> addMyKeyword(
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser, 
+    public ResponseEntity<ApiResponse<EmptyResponse>> addMyKeyword(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestBody UserKeywordRequestDTO request
     ) {
         if (currentUser == null) throw new AuthException(ErrorMessage.AUTH_UNAUTHORIZED);
         userKeywordService.addKeyword(currentUser.getId(), request.getKeyword());
-        return ApiResponse.success("키워드 등록 성공");
+        return ResponseEntity.ok(ApiResponse.success("키워드 등록 성공"));
     }
 
     @Operation(
@@ -109,13 +110,13 @@ public class UserKeywordController {
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @DeleteMapping("/me/{keywordId}")
-    public ApiResponse<EmptyResponse> deleteMyKeyword(
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser, 
+    public ResponseEntity<ApiResponse<EmptyResponse>> deleteMyKeyword(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @PathVariable("keywordId") Long keywordId
     ) {
         if (currentUser == null) throw new AuthException(ErrorMessage.AUTH_UNAUTHORIZED);
         userKeywordService.removeKeywordById(currentUser.getId(), keywordId);
-        return ApiResponse.success("키워드 삭제 성공");
+        return ResponseEntity.ok(ApiResponse.success("키워드 삭제 성공"));
     }
 
     @Operation(
@@ -123,23 +124,23 @@ public class UserKeywordController {
         description = """
             특정 키워드로 매칭된 캠페인 목록을 조회합니다.
             등록되지 않은 키워드로 조회 시 404 에러를 반환합니다.
-            
+
             **쿼리 파라미터 예시:**
             - ?page=0&size=20&keyword=고기
             - ?page=1&size=10&keyword=서울
-            
-            page : 페이지 번호 
-            
+
+            page : 페이지 번호
+
             size : 페이지 크기 (한 페이지당 캠페인 수)
-            
+
             sort : 정렬 기준 (예: reviewerAnnouncement,desc) -> 선택사항
-            
+
             **주의:** 이는 Request Body가 아닌 **Query Parameter**입니다.
             """,
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @GetMapping("/campaigns/personalized")
-    public ApiResponse<PageListResponseDTO<CampaignResponseDTO>> getPersonalizedCampaignsByKeyword(
+    public ResponseEntity<ApiResponse<PageListResponseDTO<CampaignResponseDTO>>> getPersonalizedCampaignsByKeyword(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestParam("keyword") String keyword,
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
@@ -147,7 +148,7 @@ public class UserKeywordController {
     ) {
         Page<CampaignResponseDTO> campaigns = userKeywordService.getPersonalizedCampaignsByKeyword(keyword, date, currentUser.getId(), pageable);
         PageListResponseDTO<CampaignResponseDTO> response = PageListResponseDTO.from(campaigns);
-        return ApiResponse.success("맞춤형 캠페인 조회 성공", response);
+        return ResponseEntity.ok(ApiResponse.success("맞춤형 캠페인 조회 성공", response));
     }
 
     @Operation(
@@ -156,12 +157,12 @@ public class UserKeywordController {
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @DeleteMapping("/alerts")
-    public ApiResponse<Void> deleteKeywordAlert(
+    public ResponseEntity<ApiResponse<Void>> deleteKeywordAlert(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestBody AlertIdsRequestDTO request
     ) {
         userKeywordService.deleteKeywordAlert(currentUser.getId(), request.getAlertIds());
-        return ApiResponse.success("키워드 알림 삭제 성공", null);
+        return ResponseEntity.ok(ApiResponse.success("키워드 알림 삭제 성공", null));
     }
 
     @Operation(
@@ -170,11 +171,11 @@ public class UserKeywordController {
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @PatchMapping("/alerts/read")
-    public ApiResponse<Void> markKeywordAlertsAsRead(
+    public ResponseEntity<ApiResponse<Void>> markKeywordAlertsAsRead(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestBody AlertIdsRequestDTO request
     ) {
         userKeywordService.markKeywordAlertsAsRead(currentUser.getId(), request.getAlertIds());
-        return ApiResponse.success("키워드 알림 읽음 처리 성공", null);
+        return ResponseEntity.ok(ApiResponse.success("키워드 알림 읽음 처리 성공", null));
     }
 } 

--- a/src/main/java/com/example/cherrydan/user/domain/KeywordCampaignAlert.java
+++ b/src/main/java/com/example/cherrydan/user/domain/KeywordCampaignAlert.java
@@ -47,7 +47,7 @@ public class KeywordCampaignAlert extends BaseTimeEntity {
         // 발송 완료 상태로 변경 (간단!)
         this.alertStage = 1;
     }
-    
+
     public boolean isNotified() {
         return alertStage > 0;
     }
@@ -57,5 +57,12 @@ public class KeywordCampaignAlert extends BaseTimeEntity {
      */
     public void markAsRead() {
         this.isRead = true;
+    }
+
+    /**
+     * 숨김 처리 (소프트 삭제)
+     */
+    public void hide() {
+        this.isVisibleToUser = false;
     }
 } 

--- a/src/main/java/com/example/cherrydan/user/repository/KeywordCampaignAlertRepository.java
+++ b/src/main/java/com/example/cherrydan/user/repository/KeywordCampaignAlertRepository.java
@@ -34,4 +34,10 @@ public interface KeywordCampaignAlertRepository extends JpaRepository<KeywordCam
     @Query("UPDATE KeywordCampaignAlert kca SET kca.isRead = true WHERE kca.user.id = :userId AND kca.alertDate = :date AND kca.keyword = :keyword AND kca.isRead = false")
     @org.springframework.data.jpa.repository.Modifying
     void markAsReadByUserAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword, @Param("date") LocalDate date);
+
+    /**
+     * 사용자의 미읽은 키워드 알림 개수 조회
+     */
+    @Query("SELECT COUNT(kca) FROM KeywordCampaignAlert kca WHERE kca.user.id = :userId AND kca.isRead = false AND kca.isVisibleToUser = true")
+    long countUnreadByUserId(@Param("userId") Long userId);
 } 

--- a/src/main/java/com/example/cherrydan/user/repository/KeywordCampaignAlertRepository.java
+++ b/src/main/java/com/example/cherrydan/user/repository/KeywordCampaignAlertRepository.java
@@ -4,6 +4,7 @@ import com.example.cherrydan.user.domain.KeywordCampaignAlert;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
@@ -32,12 +33,12 @@ public interface KeywordCampaignAlertRepository extends JpaRepository<KeywordCam
      * 사용자가 키워드로 캠페인 조회시 해당 키워드 알림을 읽음 처리
      */
     @Query("UPDATE KeywordCampaignAlert kca SET kca.isRead = true WHERE kca.user.id = :userId AND kca.alertDate = :date AND kca.keyword = :keyword AND kca.isRead = false")
-    @org.springframework.data.jpa.repository.Modifying
+    @Modifying
     void markAsReadByUserAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword, @Param("date") LocalDate date);
 
     /**
      * 사용자의 미읽은 키워드 알림 개수 조회
      */
     @Query("SELECT COUNT(kca) FROM KeywordCampaignAlert kca WHERE kca.user.id = :userId AND kca.isRead = false AND kca.isVisibleToUser = true")
-    long countUnreadByUserId(@Param("userId") Long userId);
+    Long countUnreadByUserId(@Param("userId") Long userId);
 } 

--- a/src/main/java/com/example/cherrydan/user/service/UserKeywordService.java
+++ b/src/main/java/com/example/cherrydan/user/service/UserKeywordService.java
@@ -190,21 +190,22 @@ public class UserKeywordService {
     }
 
     /**
-     * 맞춤형 알림 삭제 (배열)
+     * 맞춤형 알림 삭제 (소프트 삭제)
      */
     @Transactional
     public void deleteKeywordAlert(Long userId, List<Long> alertIds) {
         List<KeywordCampaignAlert> alerts = keywordAlertRepository.findAllById(alertIds);
-        
+
         // 모든 알림이 해당 사용자의 것인지 확인
         for (KeywordCampaignAlert alert : alerts) {
             if (!alert.getUser().getId().equals(userId)) {
                 throw new UserException(ErrorMessage.USER_KEYWORD_ACCESS_DENIED);
             }
+            alert.hide();
         }
-        
-        keywordAlertRepository.deleteAll(alerts);
-        log.info("키워드 알림 삭제 완료: userId={}, count={}", userId, alertIds.size());
+
+        keywordAlertRepository.saveAll(alerts);
+        log.info("키워드 알림 숨김 처리 완료: userId={}, count={}", userId, alertIds.size());
     }
 
     /**

--- a/src/test/java/com/example/cherrydan/activity/service/AlertServiceIntegrationTest.java
+++ b/src/test/java/com/example/cherrydan/activity/service/AlertServiceIntegrationTest.java
@@ -1,0 +1,237 @@
+package com.example.cherrydan.activity.service;
+
+import com.example.cherrydan.activity.domain.ActivityAlert;
+import com.example.cherrydan.activity.domain.ActivityAlertType;
+import com.example.cherrydan.activity.dto.UnreadAlertCountResponseDTO;
+import com.example.cherrydan.activity.repository.ActivityAlertRepository;
+import com.example.cherrydan.campaign.domain.Campaign;
+import com.example.cherrydan.campaign.repository.CampaignRepository;
+import com.example.cherrydan.oauth.domain.AuthProvider;
+import com.example.cherrydan.user.domain.Gender;
+import com.example.cherrydan.user.domain.KeywordCampaignAlert;
+import com.example.cherrydan.user.domain.Role;
+import com.example.cherrydan.user.domain.User;
+import com.example.cherrydan.user.repository.KeywordCampaignAlertRepository;
+import com.example.cherrydan.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class AlertServiceIntegrationTest {
+
+    @Autowired
+    private AlertService alertService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @Autowired
+    private ActivityAlertRepository activityAlertRepository;
+
+    @Autowired
+    private KeywordCampaignAlertRepository keywordCampaignAlertRepository;
+
+    private User testUser;
+    private User otherUser;
+    private Campaign testCampaign;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(User.builder()
+                .name("테스트유저")
+                .email("test@example.com")
+                .socialId("test123")
+                .provider(AuthProvider.KAKAO)
+                .role(Role.ROLE_USER)
+                .gender(Gender.MALE)
+                .isActive(true)
+                .build());
+
+        otherUser = userRepository.save(User.builder()
+                .name("다른유저")
+                .email("other@example.com")
+                .socialId("other123")
+                .provider(AuthProvider.KAKAO)
+                .role(Role.ROLE_USER)
+                .gender(Gender.FEMALE)
+                .isActive(true)
+                .build());
+
+        testCampaign = campaignRepository.save(Campaign.builder()
+                .title("테스트 캠페인")
+                .detailUrl("https://test.com/campaign1")
+                .isActive(true)
+                .build());
+    }
+
+    @Test
+    @DisplayName("미읽은 알림 개수를 정확히 조회한다")
+    void getUnreadAlertCount_success() {
+        // Given: 테스트 유저의 미읽은 알림 생성
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.BOOKMARK_DEADLINE_D1, false, true);  // 미읽음, 활동 알림
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.BOOKMARK_DEADLINE_DDAY, false, true);  // 미읽음, 활동 알림
+        createKeywordAlert(testUser, "뷰티", false, true);  // 미읽음, 키워드 알림
+
+        // When
+        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(testUser.getId());
+
+        // Then
+        assertThat(result.getTotalCount()).isEqualTo(3L);
+        assertThat(result.getActivityAlertCount()).isEqualTo(2L);
+        assertThat(result.getKeywordAlertCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("읽은 알림은 개수에 포함되지 않는다")
+    void getUnreadAlertCount_excludeReadAlerts() {
+        // Given
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.APPLY_RESULT_DDAY, false, true);  // 미읽음
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.SELECTED_VISIT_D3, true, true);   // 읽음
+        createKeywordAlert(testUser, "맛집", false, true);  // 미읽음
+        createKeywordAlert(testUser, "카페", true, true);   // 읽음
+
+        // When
+        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(testUser.getId());
+
+        // Then
+        assertThat(result.getTotalCount()).isEqualTo(2L);
+        assertThat(result.getActivityAlertCount()).isEqualTo(1L);
+        assertThat(result.getKeywordAlertCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("보이지 않는 알림은 개수에 포함되지 않는다")
+    void getUnreadAlertCount_excludeInvisibleAlerts() {
+        // Given
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.SELECTED_VISIT_DDAY, false, true);   // 보임
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.REVIEWING_DEADLINE_D3, false, false);  // 숨김
+        createKeywordAlert(testUser, "뷰티", false, true);   // 보임
+        createKeywordAlert(testUser, "맛집", false, false);  // 숨김
+
+        // When
+        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(testUser.getId());
+
+        // Then
+        assertThat(result.getTotalCount()).isEqualTo(2L);
+        assertThat(result.getActivityAlertCount()).isEqualTo(1L);
+        assertThat(result.getKeywordAlertCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 알림은 개수에 포함되지 않는다")
+    void getUnreadAlertCount_excludeOtherUserAlerts() {
+        // Given: 테스트 유저의 알림
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.REVIEWING_DEADLINE_DDAY, false, true);
+        createKeywordAlert(testUser, "뷰티", false, true);
+
+        // 다른 유저의 알림
+        createActivityAlert(otherUser, testCampaign, ActivityAlertType.BOOKMARK_DEADLINE_D1, false, true);
+        createKeywordAlert(otherUser, "맛집", false, true);
+
+        // When
+        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(testUser.getId());
+
+        // Then: 테스트 유저의 알림만 카운트
+        assertThat(result.getTotalCount()).isEqualTo(2L);
+        assertThat(result.getActivityAlertCount()).isEqualTo(1L);
+        assertThat(result.getKeywordAlertCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("미읽은 알림이 없으면 0을 반환한다")
+    void getUnreadAlertCount_noUnreadAlerts() {
+        // Given: 읽은 알림만 존재
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.BOOKMARK_DEADLINE_DDAY, true, true);
+        createKeywordAlert(testUser, "뷰티", true, true);
+
+        // When
+        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(testUser.getId());
+
+        // Then
+        assertThat(result.getTotalCount()).isEqualTo(0L);
+        assertThat(result.getActivityAlertCount()).isEqualTo(0L);
+        assertThat(result.getKeywordAlertCount()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("알림이 전혀 없으면 0을 반환한다")
+    void getUnreadAlertCount_noAlerts() {
+        // Given: 알림 없음
+
+        // When
+        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(testUser.getId());
+
+        // Then
+        assertThat(result.getTotalCount()).isEqualTo(0L);
+        assertThat(result.getActivityAlertCount()).isEqualTo(0L);
+        assertThat(result.getKeywordAlertCount()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("복합 조건 테스트: 미읽음, 읽음, 숨김, 다른 유저 알림이 섞여있을 때")
+    void getUnreadAlertCount_complexScenario() {
+        // Given
+        // 테스트 유저의 미읽은 알림 (카운트 O)
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.BOOKMARK_DEADLINE_D1, false, true);
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.BOOKMARK_DEADLINE_DDAY, false, true);
+        createKeywordAlert(testUser, "뷰티", false, true);
+
+        // 테스트 유저의 읽은 알림 (카운트 X)
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.APPLY_RESULT_DDAY, true, true);
+        createKeywordAlert(testUser, "맛집", true, true);
+
+        // 테스트 유저의 숨김 알림 (카운트 X)
+        createActivityAlert(testUser, testCampaign, ActivityAlertType.SELECTED_VISIT_D3, false, false);
+        createKeywordAlert(testUser, "카페", false, false);
+
+        // 다른 유저의 미읽은 알림 (카운트 X)
+        createActivityAlert(otherUser, testCampaign, ActivityAlertType.SELECTED_VISIT_DDAY, false, true);
+        createKeywordAlert(otherUser, "서울", false, true);
+
+        // When
+        UnreadAlertCountResponseDTO result = alertService.getUnreadAlertCount(testUser.getId());
+
+        // Then: 테스트 유저의 미읽은 + 보이는 알림만 카운트
+        assertThat(result.getTotalCount()).isEqualTo(3L);
+        assertThat(result.getActivityAlertCount()).isEqualTo(2L);
+        assertThat(result.getKeywordAlertCount()).isEqualTo(1L);
+    }
+
+    private void createActivityAlert(User user, Campaign campaign, ActivityAlertType alertType, boolean isRead, boolean isVisible) {
+        ActivityAlert alert = ActivityAlert.builder()
+                .user(user)
+                .campaign(campaign)
+                .alertDate(LocalDate.now())
+                .alertType(alertType)
+                .alertStage(0)
+                .isVisibleToUser(isVisible)
+                .isRead(isRead)
+                .build();
+        activityAlertRepository.save(alert);
+    }
+
+    private void createKeywordAlert(User user, String keyword, boolean isRead, boolean isVisible) {
+        KeywordCampaignAlert alert = KeywordCampaignAlert.builder()
+                .user(user)
+                .keyword(keyword)
+                .campaignCount(10)
+                .alertDate(LocalDate.now())
+                .alertStage(0)
+                .isVisibleToUser(isVisible)
+                .isRead(isRead)
+                .build();
+        keywordCampaignAlertRepository.save(alert);
+    }
+}


### PR DESCRIPTION
### 추가 내용
  - 미읽은 알림 개수 조회 API 구현 (GET /api/alerts/unread-count)
    - AlertController, AlertService, UnreadAlertCountResponseDTO 신규 생성
    - ActivityAlertRepository, KeywordCampaignAlertRepository에 countUnreadByUserId() 추가
  - Controller 반환 타입 통일 (ApiResponse → ResponseEntity<ApiResponse>)
    - ActivityController, UserKeywordController, SnsController
    - REST 표준 준수 및 HTTP 상태코드 제어 가능
  - 알림 삭제 방식 변경 (Hard Delete → Soft Delete)
    - ActivityAlert, KeywordCampaignAlert에 hide() 메서드 추가
    - deleteAll() 대신 isVisibleToUser = false로 변경
  - 타입 최적화
    - 알림 개수 타입을 Integer → Long으로 변경하여 불필요한 형변환 제거
  - 통합 테스트 추가 (AlertServiceIntegrationTest)

  ### 추가 이유

  **미읽은 알림 개수 조회 API 필요성**
  - 클라이언트가 홈 화면 알림 배지에 미읽은 알림 개수를 표시해야 함
  - 활동 알림과 키워드 알림의 미읽은 개수를 각각 제공하여 탭별 배지 표시 가능

  **단순 COUNT 쿼리 방식 선택 이유 (vs 캐시/CQRS)**

  1. **Redis 캐싱 방식 배제**
     - 알림은 하루 1회(새벽 배치) 생성되므로 데이터 변경 빈도가 낮음
     - 읽음 처리 시 캐시 무효화 필요 → 복잡도 증가

  2. **CQRS 패턴 (별도 Summary 테이블) 배제**
     ```java
     // 별도 테이블 생성 방식
     @Entity
     class UserNotificationSummary {
         private Long userId;
         private Integer unreadActivityCount;
         private Integer unreadKeywordCount;
     }
  - 알림 생성/읽음/삭제 시마다 Summary 테이블 동기화 필요
  - 배치 처리 시 Summary 업데이트 로직 추가 필요
  - 알림 조회 빈도가 초당 수천 건 이상이 아니면 불필요

  3. **선택한 방식: COUNT 쿼리 + 인덱스 최적화**
```
  SELECT COUNT(*) FROM activity_alerts
  WHERE user_id = ? AND is_read = false AND is_visible_to_user = true;
```

- 인덱스: idx_user_read_visible (user_id, is_read, is_visible_to_user)
- 복합 인덱스로 커버링 인덱스 활성화 → 인덱스만으로 COUNT 처리
- 쿼리 복잡도 낮고 유지보수 용이
- 실시간 정확도 보장
