### PR TITLE
fix: enum error fix & pageable 컨밴션 유지

### DIFF
--- a/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
+++ b/src/main/java/com/example/cherrydan/campaign/controller/BookmarkController.java
@@ -12,7 +12,9 @@ import com.example.cherrydan.common.exception.CampaignException;
 import com.example.cherrydan.common.exception.ErrorMessage;
 import com.example.cherrydan.oauth.security.jwt.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -50,14 +52,19 @@ public class BookmarkController {
 
     @Operation(
         summary = "북마크 목록 조회",
-        description = "case 파라미터(open/closed)로 북마크 목록을 조회합니다. open: 기간 남은 북마크, closed: 기간 지난 북마크"
+        description = "case 파라미터(likedOpen/likedClosed)로 북마크 목록을 조회합니다. likedOpen: 기간 남은 북마크, likedClosed: 기간 지난 북마크"
     )
     @GetMapping("/bookmarks")
     public ResponseEntity<ApiResponse<PageListResponseDTO<BookmarkResponseDTO>>> getBookmarksByCase(
-            @Parameter(description = "북마크 케이스 (open: 기간 남은 북마크, closed: 기간 지난 북마크)", required = false)
-            @RequestParam(value = "case", defaultValue = "open") String caseParam,
-            @AuthenticationPrincipal UserDetailsImpl currentUser,
-            Pageable pageable
+            @Parameter(description = "북마크 케이스 (likedOpen: 기간 남은 북마크, likedClosed: 기간 지난 북마크)")
+            @RequestParam(value = "case", defaultValue = "likedOpen") String caseParam,
+            @Parameter(description = "정렬 기준 createdAt", example = "createdAt")
+            @RequestParam(defaultValue = "createdAt") String sort,
+            @Parameter(description = "페이지 번호", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") int size,
+            @AuthenticationPrincipal UserDetailsImpl currentUser
     ) {
         BookmarkCase bookmarkCase;
         try {
@@ -65,7 +72,8 @@ public class BookmarkController {
         } catch (IllegalArgumentException e) {
             throw new CampaignException(ErrorMessage.CAMPAIGN_STATUS_INVALID);
         }
-        
+
+        Pageable pageable = createPageable(page, size, sort);
         PageListResponseDTO<BookmarkResponseDTO> result = bookmarkService.getBookmarksByCase(currentUser.getId(), bookmarkCase, pageable);
         String message = bookmarkCase == BookmarkCase.LIKED_OPEN ? "신청 가능한 공고 목록 조회 성공" : "신청 마감된 공고 목록 조회 성공";
         return ResponseEntity.ok(ApiResponse.success(message, result));
@@ -79,5 +87,9 @@ public class BookmarkController {
     ) {
         bookmarkService.deleteBookmark(currentUser.getId(), request);
         return ResponseEntity.ok(ApiResponse.success("북마크 삭제 성공"));
+    }
+
+    private Pageable createPageable(int page, int size, String sort) {
+        return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, sort));
     }
 } 


### PR DESCRIPTION
 ### 변경 내용
  - BookmarkController의 북마크 목록 조회 API 파라미터 구조를 CampaignController와 일관되게 개선했습니다
  - Pageable 객체를 개별 파라미터(sort, page, size)로 분리하여 Swagger 문서 가독성을 향상시켰습니다
  - 정렬 기준을 createdAt DESC로 고정하되, sort 파라미터를 통해 확장 가능성을 유지했습니다
  - case 파라미터 설명을 실제 enum 값(likedOpen/likedClosed)에 맞게 수정했습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced bookmark filtering with support for additional case values (likedOpen/likedClosed).

* **Improvements**
  * Refined pagination and sorting parameters for the bookmarks endpoint, providing explicit control over page size, sorting direction, and result ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->