### PR TITLE
feat: Prometheus 히스토그램 메트릭 수집을 활성화했습니다

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -139,6 +139,14 @@ management:
       enabled: true
     livenessstate:
       enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -141,3 +141,11 @@ management:
       enabled: true
     livenessstate:
       enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,7 @@ management:
     metrics:
       export:
         enabled: true
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true


### PR DESCRIPTION
- P95, P99 등 백분위수 계산을 위한 http.server.requests 히스토그램 활성화
- application.yml, application-dev.yml, application-prod.yml에 설정 추가
- Grafana Alert에서 응답시간 분포 기반 알림 설정 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Prometheus metrics export across all environments.
  * Added HTTP server request percentile histogram tracking to enhance metrics collection capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->